### PR TITLE
Fix memo category navigation and improve mind map mobile controls

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -1650,7 +1650,7 @@ if ($view === 'map_edit') {
       .sidebar input,.sidebar select{width:100%;padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.76);color:var(--text-strong);font:500 15px/1.5 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
       .sidebar input:focus,.sidebar select:focus{border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.16),inset 0 0 0 1px rgba(227,198,139,.22);outline:none}
       .actions,.toolbar{display:flex;flex-wrap:wrap;gap:12px;margin-top:6px}
-      .sidebar button,.map-toolbar button,.mobile-toolbar button{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .sidebar button,.map-toolbar button,.mobile-toolbar button{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden;touch-action:manipulation}
       .sidebar button::after,.map-toolbar button::after,.mobile-toolbar button::after{content:none}
       .sidebar button:hover,.map-toolbar button:hover,.mobile-toolbar button:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
       .sidebar button:active,.map-toolbar button:active,.mobile-toolbar button:active{transform:translateY(0);border-color:var(--gold-700);background:rgba(21,26,30,.92)}
@@ -1951,6 +1951,7 @@ if ($view === 'map_edit') {
           this.linkRegistry=new Map();
           this.resizeObserver=typeof ResizeObserver!=='undefined'?new ResizeObserver(entries=>this.handleNodeResize(entries)):null;
           this.setupPan();
+          this.setupTouchGuards();
         }
         setupPan(){
           const updatePinchBaseline=()=>{
@@ -2199,6 +2200,60 @@ if ($view === 'map_edit') {
           this.render();
           this.select_node(parent.id);
           this.emit(SimpleMind.event_type.update);
+        }
+        setupTouchGuards(){
+          let lastTapTime=0;
+          let lastTapX=0;
+          let lastTapY=0;
+          let tapTimer=null;
+          const DOUBLE_TAP_DELAY=320;
+          const DOUBLE_TAP_DISTANCE=26;
+          const reset=()=>{
+            if(tapTimer){ clearTimeout(tapTimer); tapTimer=null; }
+            lastTapTime=0;
+          };
+          const isEditableTarget=(target)=>{
+            if(!target || !target.tagName) return false;
+            const tag=target.tagName.toLowerCase();
+            return tag==='input' || tag==='textarea' || tag==='select' || target.isContentEditable===true;
+          };
+          this.container.addEventListener('touchstart',(evt)=>{
+            if(evt.touches.length>1){ reset(); return; }
+            const target=evt.target;
+            if(isEditableTarget(target)){ reset(); return; }
+            const touch=evt.touches[0];
+            const now=performance.now();
+            if(lastTapTime){
+              const delta=now-lastTapTime;
+              const dx=touch.clientX-lastTapX;
+              const dy=touch.clientY-lastTapY;
+              if(delta>0 && delta<=DOUBLE_TAP_DELAY && (dx*dx + dy*dy) <= (DOUBLE_TAP_DISTANCE*DOUBLE_TAP_DISTANCE)){
+                evt.preventDefault();
+                const dblTarget=target || this.container;
+                const dblEvt=new MouseEvent('dblclick',{
+                  bubbles:true,
+                  cancelable:true,
+                  clientX:touch.clientX,
+                  clientY:touch.clientY,
+                });
+                dblTarget.dispatchEvent(dblEvt);
+                reset();
+                return;
+              }
+            }
+            lastTapTime=now;
+            lastTapX=touch.clientX;
+            lastTapY=touch.clientY;
+            if(tapTimer){ clearTimeout(tapTimer); }
+            tapTimer=setTimeout(reset, DOUBLE_TAP_DELAY+60);
+          },{passive:false});
+          this.container.addEventListener('touchend',(evt)=>{
+            if(evt.touches && evt.touches.length>0) return;
+            if(isEditableTarget(evt.target)){ reset(); return; }
+            if(tapTimer){ clearTimeout(tapTimer); }
+            tapTimer=setTimeout(reset, DOUBLE_TAP_DELAY);
+          });
+          this.container.addEventListener('touchcancel', reset);
         }
         toggle_node(id){
           const node=this.nodes.get(id);
@@ -3075,7 +3130,7 @@ if ($view === 'map_edit') {
           saveState.textContent='未保存';
           saveState.classList.add('show','dirty');
         }
-        setSaveButtonState(null,false);
+        setSaveButtonState('未保存',false);
         setMobileSaveStatus('未保存','dirty');
       }
       function showSaving(){

--- a/memo.php
+++ b/memo.php
@@ -1671,12 +1671,16 @@ if ($view === 'map_edit') {
       #jsmind-container{position:relative;width:100%;height:100vh;height:100dvh;overflow:hidden;background:linear-gradient(160deg,rgba(21,26,30,.82),rgba(10,12,14,.94));box-shadow:inset 0 0 48px rgba(0,0,0,.6);touch-action:none}
       .mind-background{position:absolute;inset:0;background:radial-gradient(circle at 18% 24%,rgba(227,198,139,.08),transparent 55%),radial-gradient(circle at 68% 12%,rgba(227,198,139,.05),transparent 60%),linear-gradient(120deg,rgba(201,168,106,.06),transparent 65%);pointer-events:none;opacity:.8}
       .mind-viewport,.mind-links{position:absolute;top:0;left:0;transform-origin:0 0}
-      .mind-links{pointer-events:none;filter:drop-shadow(0 0 8px rgba(227,198,139,.25))}
-      .mind-links path{fill:none;stroke:var(--fiber);stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:18 32;animation:fiberFlow 8s linear infinite}
-      .mind-links path[data-status="doing"]{stroke:var(--gold-400);stroke-dasharray:12 24;animation:fiberPulse 3s linear infinite}
-      .mind-links path[data-status="done"]{stroke:rgba(201,168,106,.5);opacity:.8;stroke-dasharray:20 36}
-      @keyframes fiberFlow{0%{stroke-dashoffset:0;opacity:.85}100%{stroke-dashoffset:-480;opacity:1}}
-      @keyframes fiberPulse{0%{stroke-dashoffset:0;opacity:.9}100%{stroke-dashoffset:-320;opacity:1}}
+      .mind-links{pointer-events:none;overflow:visible}
+      .mind-links .trace-group{mix-blend-mode:screen}
+      .mind-links .trace-layer{fill:none;pointer-events:none;stroke-linecap:round;stroke-linejoin:bevel}
+      .mind-links .trace-underlay{stroke:rgba(122,94,54,.58);stroke-width:2.6;opacity:.55;filter:url(#mind-soft-glow);stroke-linejoin:round}
+      .mind-links .trace-core{stroke-width:1.6;filter:url(#mind-soft-glow)}
+      .mind-links .trace-core.padded{marker-start:url(#mind-pad-round);marker-end:url(#mind-pad-round)}
+      .mind-links .trace-highlight{stroke:rgba(255,242,218,.34);stroke-width:0.8;filter:url(#mind-soft-glow);opacity:.85}
+      .mind-links .trace-group.status-doing .trace-core{stroke-opacity:.95}
+      .mind-links .trace-group.status-done .trace-core{opacity:.68}
+      .mind-links .trace-group.status-done .trace-highlight{opacity:.5}
       .mind-nodes{position:absolute;top:0;left:0}
       .jsmind-node{position:absolute;display:flex;flex-direction:column;align-items:flex-start;gap:10px;padding:18px 20px;border-radius:var(--r-md);color:var(--text-strong);font:600 14px/1.5 'Inter','Noto Sans SC',sans-serif;min-width:170px;max-width:320px;background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));border:1.6px solid rgba(201,168,106,.32);box-shadow:0 20px 48px rgba(0,0,0,.58),0 0 30px rgba(227,198,139,.12);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),filter var(--transition);backdrop-filter:blur(12px);letter-spacing:.04em}
       @media (max-width:600px){
@@ -1704,10 +1708,6 @@ if ($view === 'map_edit') {
       .mobile-toolbar{position:fixed;left:50%;bottom:26px;transform:translateX(-50%);width:min(640px,calc(100% - 32px));display:grid;grid-template-columns:repeat(auto-fit,minmax(88px,1fr));gap:8px;background:rgba(12,16,18,.88);border:1px solid rgba(201,168,106,.28);border-radius:20px;padding:12px;box-shadow:0 18px 36px rgba(0,0,0,.5);backdrop-filter:blur(16px);z-index:80}
       .mobile-toolbar button{min-width:0;padding:10px 12px;width:100%}
       @media (max-width:820px){.map-toolbar{display:none}}
-      .mobile-save-status{position:fixed;left:50%;bottom:90px;transform:translateX(-50%);padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.34);background:rgba(21,26,30,.9);color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;box-shadow:0 18px 44px rgba(0,0,0,.55);backdrop-filter:blur(14px);opacity:0;pointer-events:none;transition:opacity var(--t) ease;z-index:85}
-      .mobile-save-status.show{opacity:1}
-      .mobile-save-status.state-success{border-color:rgba(36,194,160,.42);color:#CFFAEA;box-shadow:0 0 28px rgba(36,194,160,.32)}
-      .mobile-save-status.state-error{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:0 0 28px rgba(209,75,75,.32)}
       .sidebar-toggle{position:absolute;top:22px;left:22px;padding:10px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.86);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;display:none;z-index:95;box-shadow:0 12px 28px rgba(0,0,0,.45)}
       @media (max-width:1024px){
         .sidebar{position:fixed;left:0;top:0;bottom:0;width:min(86vw,360px);transform:translateX(-105%);transition:transform var(--transition);border-right:1px solid rgba(201,168,106,.28);border-radius:0 24px 24px 0}
@@ -1832,13 +1832,15 @@ if ($view === 'map_edit') {
           <button data-action="attach-link">链接</button>
           <button data-action="delete" class="danger">删除</button>
         </div>
-        <div class="mobile-save-status" id="mobile-save-status" role="status" aria-live="polite"></div>
       </main>
     </div>
     <div class="sidebar-backdrop" id="sidebar-backdrop" hidden></div>
     <script>
       (function(){
       const DOUBLE_TAP_WINDOW=320;
+      const SVG_NS='http://www.w3.org/2000/svg';
+      const TRACE_GRID=8;
+      const TRACE_CHAMFER=6;
       const NODE_TYPES=[
         {value:'idea',label:'创意',icon:'💡',accent:'#0284c7'},
         {value:'task',label:'任务',icon:'✅',accent:'#ca8a04'},
@@ -1930,8 +1932,12 @@ if ($view === 'map_edit') {
           this.container.appendChild(this.background);
           this.viewport=document.createElement('div');
           this.viewport.className='mind-viewport';
-          this.linkLayer=document.createElementNS('http://www.w3.org/2000/svg','svg');
+          this.linkLayer=document.createElementNS(SVG_NS,'svg');
           this.linkLayer.classList.add('mind-links');
+          this.linkLayer.setAttribute('width','100%');
+          this.linkLayer.setAttribute('height','100%');
+          this.linkDefs=null;
+          this.initializeLinkDefs();
           this.viewport.appendChild(this.linkLayer);
           this.nodeLayer=document.createElement('div');
           this.nodeLayer.className='mind-nodes';
@@ -1952,6 +1958,192 @@ if ($view === 'map_edit') {
           this.resizeObserver=typeof ResizeObserver!=='undefined'?new ResizeObserver(entries=>this.handleNodeResize(entries)):null;
           this.setupPan();
           this.setupTouchGuards();
+        }
+        initializeLinkDefs(){
+          if(!this.linkLayer) return;
+          if(this.linkDefs && this.linkDefs.parentNode===this.linkLayer){
+            this.linkLayer.removeChild(this.linkDefs);
+          }
+          const defs=document.createElementNS(SVG_NS,'defs');
+          defs.setAttribute('data-static-defs','true');
+          const softGlow=document.createElementNS(SVG_NS,'filter');
+          softGlow.id='mind-soft-glow';
+          softGlow.setAttribute('x','-50%');
+          softGlow.setAttribute('y','-50%');
+          softGlow.setAttribute('width','200%');
+          softGlow.setAttribute('height','200%');
+          const blur=document.createElementNS(SVG_NS,'feGaussianBlur');
+          blur.setAttribute('in','SourceGraphic');
+          blur.setAttribute('stdDeviation','0.6');
+          blur.setAttribute('result','blur');
+          const merge=document.createElementNS(SVG_NS,'feMerge');
+          const mergeNodeBlur=document.createElementNS(SVG_NS,'feMergeNode');
+          mergeNodeBlur.setAttribute('in','blur');
+          const mergeNodeSource=document.createElementNS(SVG_NS,'feMergeNode');
+          mergeNodeSource.setAttribute('in','SourceGraphic');
+          merge.appendChild(mergeNodeBlur);
+          merge.appendChild(mergeNodeSource);
+          softGlow.appendChild(blur);
+          softGlow.appendChild(merge);
+          defs.appendChild(softGlow);
+          const padGradient=document.createElementNS(SVG_NS,'radialGradient');
+          padGradient.id='mind-pad-gradient';
+          padGradient.setAttribute('cx','50%');
+          padGradient.setAttribute('cy','45%');
+          padGradient.setAttribute('r','60%');
+          padGradient.setAttribute('data-static-def','true');
+          const stops=[
+            {offset:'0%',color:'#EAD8A8',opacity:'0.95'},
+            {offset:'60%',color:'#C9A86A',opacity:'0.95'},
+            {offset:'100%',color:'#7A5E36',opacity:'0.85'},
+          ];
+          stops.forEach(stopInfo=>{
+            const stop=document.createElementNS(SVG_NS,'stop');
+            stop.setAttribute('offset',stopInfo.offset);
+            stop.setAttribute('stop-color',stopInfo.color);
+            if(stopInfo.opacity){ stop.setAttribute('stop-opacity',stopInfo.opacity); }
+            padGradient.appendChild(stop);
+          });
+          defs.appendChild(padGradient);
+          const padMarker=document.createElementNS(SVG_NS,'marker');
+          padMarker.id='mind-pad-round';
+          padMarker.setAttribute('markerWidth','8');
+          padMarker.setAttribute('markerHeight','8');
+          padMarker.setAttribute('refX','4');
+          padMarker.setAttribute('refY','4');
+          padMarker.setAttribute('orient','auto');
+          const padCircle=document.createElementNS(SVG_NS,'circle');
+          padCircle.setAttribute('cx','4');
+          padCircle.setAttribute('cy','4');
+          padCircle.setAttribute('r','3.2');
+          padCircle.setAttribute('fill','url(#mind-pad-gradient)');
+          padMarker.appendChild(padCircle);
+          const fresnel=document.createElementNS(SVG_NS,'circle');
+          fresnel.setAttribute('cx','4');
+          fresnel.setAttribute('cy','4');
+          fresnel.setAttribute('r','3.6');
+          fresnel.setAttribute('fill','none');
+          fresnel.setAttribute('stroke','rgba(76,195,209,.18)');
+          fresnel.setAttribute('stroke-width','0.6');
+          padMarker.appendChild(fresnel);
+          defs.appendChild(padMarker);
+          this.linkLayer.appendChild(defs);
+          this.linkDefs=defs;
+        }
+        clearLinkLayer(){
+          if(this.linkLayer){
+            this.linkLayer.querySelectorAll('g.trace-group').forEach(group=>group.remove());
+          }
+          if(this.linkDefs){
+            this.linkDefs.querySelectorAll('[data-trace-gradient]').forEach(grad=>grad.remove());
+          }
+        }
+        updateTraceGroupState(node){
+          if(!node || !node.linkGroup) return;
+          const status=(node.data && node.data.status) || 'backlog';
+          const type=(node.data && node.data.type) || 'idea';
+          node.linkGroup.setAttribute('data-status', status);
+          node.linkGroup.setAttribute('data-type', type);
+          node.linkGroup.setAttribute('data-depth', String(node.depth||0));
+          Array.from(node.linkGroup.classList)
+            .filter(cls=>cls.startsWith('status-'))
+            .forEach(cls=>node.linkGroup.classList.remove(cls));
+          node.linkGroup.classList.add(`status-${status}`);
+        }
+        ensureTraceGradient(nodeId){
+          if(!this.linkDefs) return null;
+          const gradientId=`mind-trace-gradient-${nodeId}`;
+          let gradient=this.linkDefs.querySelector(`#${gradientId}`);
+          if(gradient) return gradient;
+          gradient=document.createElementNS(SVG_NS,'linearGradient');
+          gradient.id=gradientId;
+          gradient.setAttribute('gradientUnits','userSpaceOnUse');
+          gradient.setAttribute('data-trace-gradient', nodeId);
+          const stops=[
+            {offset:'0%',color:'#E3C68B'},
+            {offset:'50%',color:'#C9A86A'},
+            {offset:'100%',color:'#AA8C54'},
+          ];
+          stops.forEach(info=>{
+            const stop=document.createElementNS(SVG_NS,'stop');
+            stop.setAttribute('offset',info.offset);
+            stop.setAttribute('stop-color',info.color);
+            gradient.appendChild(stop);
+          });
+          this.linkDefs.appendChild(gradient);
+          return gradient;
+        }
+        snapCoordinate(value){
+          if(!Number.isFinite(value)) return 0;
+          return Math.round(value/TRACE_GRID)*TRACE_GRID;
+        }
+        formatCoordinate(value){
+          if(!Number.isFinite(value)) return 0;
+          return Math.round(value*100)/100;
+        }
+        buildTracePoints(start, end){
+          if(!start || !end) return [start,end].filter(Boolean);
+          const points=[{x:start.x,y:start.y}];
+          const dx=end.x-start.x;
+          const dirX=dx>=0?1:-1;
+          const totalDx=Math.abs(dx);
+          const approach=Math.max(20, Math.min(32, totalDx*0.25));
+          let elbowX=start.x + dirX * Math.max(32, Math.min(totalDx*0.55, totalDx - approach));
+          const finalApproach=end.x - dirX * approach;
+          if(dirX>0 && elbowX>finalApproach){ elbowX=(start.x + finalApproach)/2; }
+          if(dirX<0 && elbowX<finalApproach){ elbowX=(start.x + finalApproach)/2; }
+          elbowX=this.snapCoordinate(elbowX);
+          const horizontalPoint={x:elbowX,y:start.y};
+          if(Math.hypot(horizontalPoint.x-start.x, horizontalPoint.y-start.y)>0.5){
+            points.push(horizontalPoint);
+          }
+          if(Math.abs(end.y-start.y)>4){
+            points.push({x:elbowX,y:end.y});
+          }
+          points.push({x:end.x,y:end.y});
+          return points;
+        }
+        buildChamferedPath(points, chamfer=TRACE_CHAMFER){
+          if(!points || points.length<2) return '';
+          const fmt=value=>this.formatCoordinate(value);
+          const commands=[`M${fmt(points[0].x)} ${fmt(points[0].y)}`];
+          for(let i=1;i<points.length;i++){
+            const curr=points[i];
+            if(i===points.length-1){
+              commands.push(`L${fmt(curr.x)} ${fmt(curr.y)}`);
+              continue;
+            }
+            const prev=points[i-1];
+            const next=points[i+1];
+            const prevVec={x:curr.x-prev.x,y:curr.y-prev.y};
+            const nextVec={x:next.x-curr.x,y:next.y-curr.y};
+            const prevLen=Math.hypot(prevVec.x, prevVec.y);
+            const nextLen=Math.hypot(nextVec.x, nextVec.y);
+            if(prevLen<0.001 || nextLen<0.001){
+              commands.push(`L${fmt(curr.x)} ${fmt(curr.y)}`);
+              continue;
+            }
+            const cut=Math.min(chamfer, prevLen/2, nextLen/2);
+            const entry={
+              x:curr.x - (prevVec.x/prevLen)*cut,
+              y:curr.y - (prevVec.y/prevLen)*cut,
+            };
+            const exit={
+              x:curr.x + (nextVec.x/nextLen)*cut,
+              y:curr.y + (nextVec.y/nextLen)*cut,
+            };
+            commands.push(`L${fmt(entry.x)} ${fmt(entry.y)}`);
+            commands.push(`L${fmt(exit.x)} ${fmt(exit.y)}`);
+          }
+          return commands.join(' ');
+        }
+        computeTraceWidth(node){
+          if(!node || !node.parent) return 1.6;
+          if(node.parent.isroot) return 2.0;
+          const siblings=node.parent.children || [];
+          if(siblings.length>=6) return 1.2;
+          if(siblings.length>=4) return 1.4;
+          return 1.6;
         }
         setupPan(){
           const updatePinchBaseline=()=>{
@@ -2532,7 +2724,7 @@ if ($view === 'map_edit') {
         }
         render(){
           this.nodeLayer.innerHTML='';
-          while(this.linkLayer.firstChild){ this.linkLayer.removeChild(this.linkLayer.firstChild); }
+          this.clearLinkLayer();
           if(this.resizeObserver){ this.resizeObserver.disconnect(); }
           this.linkRegistry.clear();
           if(!this.root) return;
@@ -2549,13 +2741,31 @@ if ($view === 'map_edit') {
             this.updateNodePosition(node);
             this.updateAnchors(node);
             if(node.parent){
-              const path=document.createElementNS('http://www.w3.org/2000/svg','path');
-              path.setAttribute('data-from', node.parent.id);
-              path.setAttribute('data-to', node.id);
-              path.setAttribute('data-type', node.data && node.data.type ? node.data.type : 'idea');
-              this.linkLayer.appendChild(path);
-              node.linkPath=path;
-              this.linkRegistry.set(node.id,path);
+              const group=document.createElementNS(SVG_NS,'g');
+              group.classList.add('trace-group');
+              group.setAttribute('data-from', node.parent.id);
+              group.setAttribute('data-to', node.id);
+              group.setAttribute('data-type', node.data && node.data.type ? node.data.type : 'idea');
+              group.setAttribute('data-status', node.data && node.data.status ? node.data.status : 'backlog');
+              group.setAttribute('data-depth', String(node.depth||0));
+              const underlay=document.createElementNS(SVG_NS,'path');
+              underlay.classList.add('trace-layer','trace-underlay');
+              const core=document.createElementNS(SVG_NS,'path');
+              core.classList.add('trace-layer','trace-core','padded');
+              core.setAttribute('data-from', node.parent.id);
+              core.setAttribute('data-to', node.id);
+              const highlight=document.createElementNS(SVG_NS,'path');
+              highlight.classList.add('trace-layer','trace-highlight');
+              group.appendChild(underlay);
+              group.appendChild(core);
+              group.appendChild(highlight);
+              this.linkLayer.appendChild(group);
+              node.linkGroup=group;
+              node.linkUnderlay=underlay;
+              node.linkPath=core;
+              node.linkHighlight=highlight;
+              this.linkRegistry.set(node.id,core);
+              this.updateTraceGroupState(node);
               this.updateLinkPath(node);
             }
             if(this.resizeObserver){ this.resizeObserver.observe(node.el); }
@@ -2591,13 +2801,29 @@ if ($view === 'map_edit') {
           if(!node.parent.anchors) this.updateAnchors(node.parent);
           const parent=node.parent;
           const isLeft=node.dir===-1 || node.direction==='left' || node.absX<=parent.absX;
-          const start=isLeft ? parent.anchors.left : parent.anchors.right;
-          const end=isLeft ? node.anchors.right : node.anchors.left;
-          const horizontalGap=Math.max(60, Math.abs(end.x-start.x)*0.35);
-          const controlX=start.x + (isLeft?-horizontalGap:horizontalGap);
-          const controlY1=start.y;
-          const controlY2=end.y;
-          node.linkPath.setAttribute('d', `M${start.x} ${start.y} C ${controlX} ${controlY1} ${controlX} ${controlY2} ${end.x} ${end.y}`);
+          const startAnchor=isLeft ? parent.anchors.left : parent.anchors.right;
+          const endAnchor=isLeft ? node.anchors.right : node.anchors.left;
+          const startPoint={x:startAnchor.x,y:startAnchor.y};
+          const endPoint={x:endAnchor.x,y:endAnchor.y};
+          const points=this.buildTracePoints(startPoint,endPoint);
+          const pathData=this.buildChamferedPath(points);
+          if(!pathData) return;
+          if(node.linkUnderlay){ node.linkUnderlay.setAttribute('d', pathData); }
+          node.linkPath.setAttribute('d', pathData);
+          if(node.linkHighlight){ node.linkHighlight.setAttribute('d', pathData); }
+          const width=this.computeTraceWidth(node);
+          node.linkPath.setAttribute('stroke-width', this.formatCoordinate(width));
+          if(node.linkUnderlay){ node.linkUnderlay.setAttribute('stroke-width', this.formatCoordinate(width+0.8)); }
+          if(node.linkHighlight){ node.linkHighlight.setAttribute('stroke-width', this.formatCoordinate(Math.max(0.6, width*0.5))); }
+          const gradient=this.ensureTraceGradient(node.id);
+          if(gradient){
+            gradient.setAttribute('x1', this.formatCoordinate(startPoint.x));
+            gradient.setAttribute('y1', this.formatCoordinate(startPoint.y));
+            gradient.setAttribute('x2', this.formatCoordinate(endPoint.x));
+            gradient.setAttribute('y2', this.formatCoordinate(endPoint.y));
+            node.linkPath.setAttribute('stroke', `url(#${gradient.id})`);
+          }
+          this.updateTraceGroupState(node);
         }
         handleNodeResize(entries){
           if(!entries || !entries.length) return;
@@ -2726,14 +2952,14 @@ if ($view === 'map_edit') {
       }
       return;
     }
-    const overlay=document.createElementNS('http://www.w3.org/2000/svg','svg');
+    const overlay=document.createElementNS(SVG_NS,'svg');
     overlay.id='drag-overlay';
     overlay.setAttribute('width','100%');
     overlay.setAttribute('height','100%');
     overlay.setAttribute('viewBox','0 0 100 100');
-    const ghostLine=document.createElementNS('http://www.w3.org/2000/svg','line');
+    const ghostLine=document.createElementNS(SVG_NS,'line');
     ghostLine.setAttribute('opacity','0');
-    const ghostRing=document.createElementNS('http://www.w3.org/2000/svg','circle');
+    const ghostRing=document.createElementNS(SVG_NS,'circle');
     ghostRing.setAttribute('opacity','0');
     overlay.appendChild(ghostLine);
     overlay.appendChild(ghostRing);
@@ -3071,7 +3297,6 @@ if ($view === 'map_edit') {
       const nodeTagsPreview=document.getElementById('node-tags-preview');
       const mobileToolbar=document.getElementById('mobile-toolbar');
       const mobileSaveButton=mobileToolbar ? mobileToolbar.querySelector('button[data-action="save"]') : null;
-      const mobileSaveStatus=document.getElementById('mobile-save-status');
       const sidebarToggle=document.getElementById('sidebar-toggle');
       const sidebarBackdrop=document.getElementById('sidebar-backdrop');
       const saveButton=document.getElementById('btn-save');
@@ -3085,32 +3310,12 @@ if ($view === 'map_edit') {
       let mobileSaveDefault=mobileSaveButton ? mobileSaveButton.textContent : '保存';
       if(mobileSaveButton){ mobileSaveButton.dataset.defaultLabel=mobileSaveDefault; }
       let dirty=false;
-      let mobileStatusTimer=null;
       const commandLog=[];
       window.__mindmapCommands=commandLog;
       const ATTACH_MAX_BYTES=15*1024*1024;
       const imageExts=['.png','.jpg','.jpeg','.gif','.webp','.bmp','.svg','.avif','.heic','.heif'];
       const textExts=['.txt','.md','.markdown','.csv','.json','.yaml','.yml','.log'];
       const videoExts=['.mp4','.mov','.mkv','.avi','.webm','.m4v'];
-      function setMobileSaveStatus(text, state, opts={}){
-        if(!mobileSaveStatus) return;
-        if(mobileStatusTimer){ clearTimeout(mobileStatusTimer); mobileStatusTimer=null; }
-        if(!text){
-          mobileSaveStatus.textContent='';
-          mobileSaveStatus.className='mobile-save-status';
-          return;
-        }
-        mobileSaveStatus.textContent=text;
-        mobileSaveStatus.className='mobile-save-status show';
-        if(state){ mobileSaveStatus.classList.add(`state-${state}`); }
-        if(opts.autoHide){
-          const duration=typeof opts.duration==='number' && isFinite(opts.duration)?opts.duration:1800;
-          mobileStatusTimer=setTimeout(()=>{
-            mobileStatusTimer=null;
-            if(!dirty){ setMobileSaveStatus('', null); }
-          }, duration);
-        }
-      }
       function setSaveButtonState(text, disabled){
         if(typeof text==='string'){
           if(saveButton) saveButton.textContent=text;
@@ -3131,7 +3336,6 @@ if ($view === 'map_edit') {
           saveState.classList.add('show','dirty');
         }
         setSaveButtonState('未保存',false);
-        setMobileSaveStatus('未保存','dirty');
       }
       function showSaving(){
         if(saveState){
@@ -3140,7 +3344,6 @@ if ($view === 'map_edit') {
           saveState.classList.remove('dirty');
         }
         setSaveButtonState('⏳ 保存中...', true);
-        setMobileSaveStatus('保存中...','saving');
       }
       function markSaved(){
         dirty=false;
@@ -3150,14 +3353,20 @@ if ($view === 'map_edit') {
           saveState.classList.remove('dirty');
         }
         setSaveButtonState('✅ 保存成功', false);
-        setMobileSaveStatus('保存成功','success',{autoHide:true});
         setTimeout(()=>{
           if(!dirty){
             if(saveState) saveState.classList.remove('show');
             setSaveButtonState(null,false);
-            setMobileSaveStatus('', null);
           }
         },1500);
+      }
+      function showSaveError(message){
+        const text=message && String(message).trim()?String(message).trim():'保存失败';
+        if(saveState){
+          saveState.textContent=text;
+          saveState.classList.add('show','dirty');
+        }
+        setSaveButtonState('未保存', false);
       }
       const inspectorFields=[nodeTypeSelect,nodeStatusSelect,nodePrioritySelect,nodeOwnerInput,nodeTagsInput].filter(Boolean);
       let inspectorSyncing=false;
@@ -3723,9 +3932,10 @@ if ($view === 'map_edit') {
           if(initialData && initialData.data){ enforceRightOrientation(initialData.data); }
           markSaved();
         }catch(err){
-          alert(err.message||'保存失败');
+          const message=err && err.message ? err.message : '保存失败';
+          alert(message);
           markDirty();
-          setMobileSaveStatus(err && err.message ? err.message : '保存失败','error');
+          showSaveError(message);
         }
       }
       window.addEventListener('beforeunload',e=>{

--- a/memo.php
+++ b/memo.php
@@ -824,12 +824,11 @@ if ($view === 'new') {
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.18);opacity:.65;pointer-events:none}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.92));border:1px solid rgba(201,168,106,.28);border-radius:var(--r-lg);padding:24px;box-shadow:var(--shadow-1);backdrop-filter:blur(14px)}
       .card::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-lg) - 4px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 34px rgba(227,198,139,.08);pointer-events:none;opacity:.9}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 0 0 0 rgba(227,198,139,0);overflow:hidden}
-      .btn::after{content:"";position:absolute;inset:-1px;border-radius:inherit;background:linear-gradient(90deg,transparent,rgba(227,198,139,.18),transparent);transform:translateX(-100%);animation:scanline 2.8s linear infinite;opacity:.8}
-      @keyframes scanline{to{transform:translateX(100%)}}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 10px 30px rgba(0,0,0,.45),0 0 24px rgba(227,198,139,.16);border-color:rgba(227,198,139,.65)}
+      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .btn::after{content:none}
+      .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
       .btn:active{transform:translateY(0);background:rgba(21,26,30,.94);border-color:var(--gold-700)}
-      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));color:var(--gold-400);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 16px 32px rgba(0,0,0,.55)}
+      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));color:var(--gold-400);box-shadow:none}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 2px rgba(227,198,139,.25)}
       .row{display:grid;grid-template-columns:2fr 1fr auto;gap:16px;margin-bottom:20px;align-items:center}
       .row input,.row select{padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 15px/1.4 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
@@ -1200,13 +1199,12 @@ if ($view === 'item' && isset($_GET['id']) && ctype_digit((string)$_GET['id'])) 
       h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
       .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px;position:relative;z-index:0}
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.2);opacity:.6;pointer-events:none}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);overflow:hidden}
-      .btn::after{content:"";position:absolute;inset:-1px;border-radius:inherit;background:linear-gradient(90deg,transparent,rgba(227,198,139,.18),transparent);transform:translateX(-100%);animation:scanline 2.8s linear infinite;opacity:.8}
-      @keyframes scanline{to{transform:translateX(100%)}}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 10px 30px rgba(0,0,0,.45),0 0 24px rgba(227,198,139,.16);border-color:rgba(227,198,139,.65)}
+      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .btn::after{content:none}
+      .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
       .btn:active{transform:translateY(0);border-color:var(--gold-700);background:rgba(21,26,30,.94)}
-      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));box-shadow:0 0 0 1px rgba(227,198,139,.25),0 16px 32px rgba(0,0,0,.55)}
-      .btn.danger{color:#F8E6E6;border-color:rgba(209,75,75,.55);box-shadow:0 0 24px rgba(209,75,75,.32)}
+      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));box-shadow:none}
+      .btn.danger{color:#F8E6E6;border-color:rgba(209,75,75,.55);box-shadow:none}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.94));border:1px solid rgba(201,168,106,.32);border-radius:24px;padding:28px;box-shadow:var(--shadow-1);backdrop-filter:blur(16px)}
       .card::before{content:"";position:absolute;inset:12px;border-radius:calc(24px - 6px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 40px rgba(227,198,139,.1);pointer-events:none}
@@ -1652,15 +1650,14 @@ if ($view === 'map_edit') {
       .sidebar input,.sidebar select{width:100%;padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.76);color:var(--text-strong);font:500 15px/1.5 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
       .sidebar input:focus,.sidebar select:focus{border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.16),inset 0 0 0 1px rgba(227,198,139,.22);outline:none}
       .actions,.toolbar{display:flex;flex-wrap:wrap;gap:12px;margin-top:6px}
-      .sidebar button,.map-toolbar button,.mobile-toolbar button{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);overflow:hidden}
-      .sidebar button::after,.map-toolbar button::after,.mobile-toolbar button::after{content:"";position:absolute;inset:-1px;border-radius:inherit;background:linear-gradient(90deg,transparent,rgba(227,198,139,.18),transparent);transform:translateX(-100%);animation:scanline 2.8s linear infinite;opacity:.75}
-      @keyframes scanline{to{transform:translateX(100%)}}
-      .sidebar button:hover,.map-toolbar button:hover,.mobile-toolbar button:hover{transform:translateY(-2px);box-shadow:0 12px 30px rgba(0,0,0,.45),0 0 24px rgba(227,198,139,.16);border-color:rgba(227,198,139,.65)}
+      .sidebar button,.map-toolbar button,.mobile-toolbar button{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .sidebar button::after,.map-toolbar button::after,.mobile-toolbar button::after{content:none}
+      .sidebar button:hover,.map-toolbar button:hover,.mobile-toolbar button:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
       .sidebar button:active,.map-toolbar button:active,.mobile-toolbar button:active{transform:translateY(0);border-color:var(--gold-700);background:rgba(21,26,30,.92)}
-      .sidebar button.acc,.mobile-toolbar button.primary{background:linear-gradient(135deg,rgba(201,168,106,.2),rgba(170,140,84,.28));color:var(--bg-void);box-shadow:0 0 0 1px rgba(227,198,139,.28),0 18px 34px rgba(0,0,0,.55)}
-      .sidebar button.danger,.mobile-toolbar button.danger{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:0 0 24px rgba(209,75,75,.32)}
+      .sidebar button.acc,.mobile-toolbar button.primary{background:linear-gradient(135deg,rgba(201,168,106,.2),rgba(170,140,84,.28));color:var(--bg-void);box-shadow:none}
+      .sidebar button.danger,.mobile-toolbar button.danger{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:none}
       .btn-like{display:inline-flex;align-items:center;justify-content:center;width:100%;padding:12px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(12,16,18,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em;cursor:pointer;transition:all var(--transition)}
-      .btn-like.danger{border-color:rgba(209,75,75,.52);color:#F6D6D6;background:rgba(35,10,14,.86);box-shadow:0 20px 38px rgba(209,75,75,.32)}
+      .btn-like.danger{border-color:rgba(209,75,75,.52);color:#F6D6D6;background:rgba(35,10,14,.86);box-shadow:none}
       .inspector{margin-top:8px;padding:18px;border-radius:var(--r-md);border:1px solid rgba(201,168,106,.3);background:rgba(15,19,22,.82);box-shadow:var(--shadow-1);display:grid;gap:16px}
       .inspector h2{margin:0 0 6px;font:600 16px/1.4 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.08em;text-transform:uppercase}
       .field{display:grid;gap:8px}
@@ -1671,7 +1668,7 @@ if ($view === 'map_edit') {
       .tips strong{color:var(--gold-500);letter-spacing:.08em}
       .tips code{padding:2px 6px;border-radius:6px;background:rgba(21,26,30,.9);border:1px solid rgba(201,168,106,.26);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif}
       .editor-pane{position:relative;background:rgba(6,10,12,.35)}
-      #jsmind-container{position:relative;width:100%;height:100vh;height:100dvh;overflow:hidden;background:linear-gradient(160deg,rgba(21,26,30,.82),rgba(10,12,14,.94));box-shadow:inset 0 0 48px rgba(0,0,0,.6)}
+      #jsmind-container{position:relative;width:100%;height:100vh;height:100dvh;overflow:hidden;background:linear-gradient(160deg,rgba(21,26,30,.82),rgba(10,12,14,.94));box-shadow:inset 0 0 48px rgba(0,0,0,.6);touch-action:none}
       .mind-background{position:absolute;inset:0;background:radial-gradient(circle at 18% 24%,rgba(227,198,139,.08),transparent 55%),radial-gradient(circle at 68% 12%,rgba(227,198,139,.05),transparent 60%),linear-gradient(120deg,rgba(201,168,106,.06),transparent 65%);pointer-events:none;opacity:.8}
       .mind-viewport,.mind-links{position:absolute;top:0;left:0;transform-origin:0 0}
       .mind-links{pointer-events:none;filter:drop-shadow(0 0 8px rgba(227,198,139,.25))}
@@ -1682,6 +1679,10 @@ if ($view === 'map_edit') {
       @keyframes fiberPulse{0%{stroke-dashoffset:0;opacity:.9}100%{stroke-dashoffset:-320;opacity:1}}
       .mind-nodes{position:absolute;top:0;left:0}
       .jsmind-node{position:absolute;display:flex;flex-direction:column;align-items:flex-start;gap:10px;padding:18px 20px;border-radius:var(--r-md);color:var(--text-strong);font:600 14px/1.5 'Inter','Noto Sans SC',sans-serif;min-width:170px;max-width:320px;background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));border:1.6px solid rgba(201,168,106,.32);box-shadow:0 20px 48px rgba(0,0,0,.58),0 0 30px rgba(227,198,139,.12);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),filter var(--transition);backdrop-filter:blur(12px);letter-spacing:.04em}
+      @media (max-width:600px){
+        .mobile-toolbar{bottom:16px;padding:10px;gap:6px;border-radius:16px}
+        .mobile-toolbar button{padding:9px 10px}
+      }
       .jsmind-node::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-md) - 4px);border:1px solid rgba(201,168,106,.22);opacity:.7;pointer-events:none;animation:nodeGlow 9s ease-in-out infinite}
       .jsmind-node::after{content:"";position:absolute;inset:-14px;border-radius:calc(var(--r-md) + 10px);border:1px dashed rgba(201,168,106,.22);opacity:0;pointer-events:none}
       @keyframes nodeGlow{0%,100%{opacity:.4}50%{opacity:.85}}
@@ -1700,8 +1701,8 @@ if ($view === 'map_edit') {
       .jsmind-node.status-done{border-color:rgba(201,168,106,.28);filter:saturate(.82);opacity:.9}
       .map-toolbar{position:absolute;top:24px;right:24px;display:flex;gap:12px;z-index:60}
       .map-toolbar button{padding:10px 14px}
-      .mobile-toolbar{position:fixed;left:50%;bottom:26px;transform:translateX(-50%);display:flex;gap:10px;background:rgba(12,16,18,.88);border:1px solid rgba(201,168,106,.28);border-radius:999px;padding:10px 16px;box-shadow:0 28px 60px rgba(0,0,0,.55);backdrop-filter:blur(16px);z-index:80}
-      .mobile-toolbar button{min-width:70px;padding:10px 16px}
+      .mobile-toolbar{position:fixed;left:50%;bottom:26px;transform:translateX(-50%);width:min(640px,calc(100% - 32px));display:grid;grid-template-columns:repeat(auto-fit,minmax(88px,1fr));gap:8px;background:rgba(12,16,18,.88);border:1px solid rgba(201,168,106,.28);border-radius:20px;padding:12px;box-shadow:0 18px 36px rgba(0,0,0,.5);backdrop-filter:blur(16px);z-index:80}
+      .mobile-toolbar button{min-width:0;padding:10px 12px;width:100%}
       @media (max-width:820px){.map-toolbar{display:none}}
       .mobile-save-status{position:fixed;left:50%;bottom:90px;transform:translateX(-50%);padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.34);background:rgba(21,26,30,.9);color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;box-shadow:0 18px 44px rgba(0,0,0,.55);backdrop-filter:blur(14px);opacity:0;pointer-events:none;transition:opacity var(--t) ease;z-index:85}
       .mobile-save-status.show{opacity:1}
@@ -1920,6 +1921,10 @@ if ($view === 'map_edit') {
           this.selectedId=null;
           this.container.innerHTML='';
           this.container.classList.add('mind-container');
+          this.container.style.touchAction='none';
+          this.container.addEventListener('gesturestart',evt=>evt.preventDefault());
+          this.container.addEventListener('gesturechange',evt=>evt.preventDefault());
+          this.container.addEventListener('gestureend',evt=>evt.preventDefault());
           this.background=document.createElement('div');
           this.background.className='mind-background';
           this.container.appendChild(this.background);
@@ -1978,6 +1983,9 @@ if ($view === 'map_edit') {
               return;
             }
             this.activePointers.set(evt.pointerId,{x:evt.clientX,y:evt.clientY});
+            if(isTouch && (this.activePointers.size>=2 || !onNode)){
+              evt.preventDefault();
+            }
             if(this.activePointers.size>=2){
               for(const id of this.activePointers.keys()){
                 try{ this.container.setPointerCapture(id); }catch(_){ }
@@ -2016,6 +2024,9 @@ if ($view === 'map_edit') {
                 this.offsetY=centerY - pinch.originY*this.scale;
                 this.applyTransform();
                 return;
+              }
+              if(this.dragState && this.dragState.pointerId===evt.pointerId){
+                evt.preventDefault();
               }
             }
             if(!this.dragState || evt.pointerId!==this.dragState.pointerId) return;
@@ -3743,12 +3754,11 @@ if ($view === 'maps') {
       .header{display:flex;gap:16px;align-items:center;justify-content:space-between;flex-wrap:wrap;margin-bottom:24px}
       .header h1{margin:0;font:600 28px/1.2 'Cinzel','Noto Serif SC',serif;letter-spacing:.18em;text-transform:uppercase;color:var(--gold-400);text-shadow:0 0 26px rgba(227,198,139,.28)}
       .header .meta{color:var(--text-muted);font:14px/1.7 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em}
-      .btn{position:relative;padding:12px 18px;border-radius:16px;border:1px solid rgba(201,168,106,.38);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 0 0 0 rgba(227,198,139,0);overflow:hidden}
-      .btn::after{content:"";position:absolute;inset:2px;border-radius:12px;border:1px solid rgba(201,168,106,.22);opacity:.85;pointer-events:none;transition:opacity var(--transition)}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 24px rgba(227,198,139,.18);border-color:rgba(227,198,139,.6)}
-      .btn:hover::after{opacity:1}
-      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.26));color:var(--bg-void);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 22px 48px rgba(0,0,0,.6)}
-      .btn.danger{border-color:rgba(209,75,75,.55);color:#F6D6D6;box-shadow:0 0 24px rgba(209,75,75,.28)}
+      .btn{position:relative;padding:12px 18px;border-radius:16px;border:1px solid rgba(201,168,106,.38);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em;cursor:pointer;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .btn::after{content:none}
+      .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.6)}
+      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.26));color:var(--bg-void);box-shadow:none}
+      .btn.danger{border-color:rgba(209,75,75,.55);color:#F6D6D6;box-shadow:none}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px}
       .search{margin-top:20px;display:flex;gap:12px;align-items:center;padding:12px 16px;border-radius:18px;border:1px solid rgba(201,168,106,.34);background:linear-gradient(135deg,rgba(21,26,30,.82),rgba(15,19,22,.92));box-shadow:inset 0 0 22px rgba(0,0,0,.5);max-width:480px}
       .search input{all:unset;flex:1;color:var(--text-strong);font-size:15px;letter-spacing:.06em}
@@ -3923,13 +3933,13 @@ $all_total = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
   .brand .logo::after{content:"";position:absolute;inset:6px;border-radius:10px;border:1px solid rgba(201,168,106,.38);box-shadow:0 0 16px rgba(227,198,139,.3);animation:breathe 6s ease-in-out infinite}
   .brand h1{font:600 16px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);text-shadow:0 0 18px rgba(227,198,139,.25)}
   .controls{display:flex;gap:10px;flex-wrap:wrap;margin:10px 0 18px}
-  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:0 0 0 0 rgba(227,198,139,0);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);overflow:hidden}
-  .btn::after{content:"";position:absolute;inset:2px;border-radius:12px;border:1px solid rgba(201,168,106,.24);opacity:.85;transition:opacity var(--transition);pointer-events:none}
-  .btn:hover{transform:translateY(-2px);box-shadow:0 18px 34px rgba(0,0,0,.55),0 0 20px rgba(227,198,139,.18);border-color:rgba(227,198,139,.6)}
-  .btn:hover::after{opacity:1}
-  .btn:active{transform:translateY(0);box-shadow:0 0 12px rgba(227,198,139,.22)}
-  .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.22),rgba(170,140,84,.3));color:var(--bg-void);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 20px 40px rgba(0,0,0,.6)}
-  .btn.danger{color:var(--danger);border-color:rgba(255,93,125,.45);box-shadow:inset 0 0 16px rgba(255,93,125,.15)}
+  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:none;transition:transform var(--transition),border-color var(--transition);overflow:hidden}
+  .btn::after{content:none}
+  .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.6)}
+  .btn:hover::after{content:none}
+  .btn:active{transform:translateY(0)}
+  .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.22),rgba(170,140,84,.3));color:var(--bg-void);box-shadow:none}
+  .btn.danger{color:var(--danger);border-color:rgba(255,93,125,.45);box-shadow:none}
   .btn.small{padding:8px 12px;border-radius:12px;font-size:11px}
   .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 3px rgba(201,168,106,.25)}
   .section-title{font:600 12px/1 'Cinzel','Noto Serif SC',serif;text-transform:uppercase;letter-spacing:.24em;color:var(--gold-400);margin:14px 0 8px;text-shadow:0 0 14px rgba(227,198,139,.24)}
@@ -3939,7 +3949,7 @@ $all_total = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
   .cat:hover{transform:translateX(4px);border-color:rgba(201,168,106,.45);box-shadow:0 10px 22px rgba(0,0,0,.6)}
   .cat:hover::before{opacity:1}
   .cat.active{border-color:var(--glow);box-shadow:0 0 18px rgba(201,168,106,.3)}
-  .cat .name{font-weight:600;color:var(--text-strong);text-shadow:0 0 8px rgba(201,168,106,.18)}
+  .cat .name{flex:1;display:block;font-weight:600;color:var(--text-strong);text-shadow:0 0 8px rgba(201,168,106,.18)}
   .cat .count{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;color:var(--text-dim);letter-spacing:.14em;text-transform:uppercase}
   .footer{margin-top:18px;color:var(--text-dim);font-size:12px;line-height:1.8;text-shadow:0 0 10px rgba(201,168,106,.15)}
   .main{padding:24px 20px;background:linear-gradient(160deg,rgba(12,14,18,.82),rgba(10,12,14,.85));backdrop-filter:blur(14px) saturate(160%);position:relative}
@@ -4024,13 +4034,13 @@ $all_total = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
     <div class="section-title">分类 · Categories</div>
     <div class="cat-list" id="cat-list">
       <a class="cat <?php echo ($cat==='all'?'active':''); ?>" href="?cat=all&q=<?php echo urlencode($q); ?>">
-        <div class="name">全部 · All</div><div class="count"><?php echo $all_total; ?></div>
+        <span class="name">全部 · All</span><span class="count"><?php echo $all_total; ?></span>
       </a>
       <?php foreach ($cats as $c): ?>
-      <div class="cat <?php echo ($cat===(string)$c['id']?'active':''); ?>" data-id="<?php echo $c['id']; ?>">
-        <a href="?cat=<?php echo $c['id']; ?>&q=<?php echo urlencode($q); ?>" style="flex:1" class="name"><?php echo h($c['name']); ?></a>
-        <div class="count"><?php echo (int)($counts[$c['id']] ?? 0); ?></div>
-      </div>
+      <a class="cat <?php echo ($cat===(string)$c['id']?'active':''); ?>" data-id="<?php echo $c['id']; ?>" href="?cat=<?php echo $c['id']; ?>&q=<?php echo urlencode($q); ?>">
+        <span class="name"><?php echo h($c['name']); ?></span>
+        <span class="count"><?php echo (int)($counts[$c['id']] ?? 0); ?></span>
+      </a>
       <?php endforeach; ?>
     </div>
     <div class="footer">
@@ -4220,14 +4230,15 @@ function refreshSidebarCats(cats, counts, total){
   const all=document.createElement('a');
   all.className='cat'+(urlCat==='all'?' active':'');
   all.href='?cat=all&q='+encodeURIComponent(qParam);
-  all.innerHTML='<div class="name">全部 · All</div><div class="count">'+(total??0)+'</div>';
+  all.innerHTML='<span class="name">全部 · All</span><span class="count">'+(total??0)+'</span>';
   list.appendChild(all);
   cats.forEach(c=>{
-    const div=document.createElement('div');
-    div.className='cat'+(String(urlCat)===String(c.id)?' active':'');
-    div.dataset.id=c.id;
-    div.innerHTML=`<a href="?cat=${c.id}&q=${encodeURIComponent(qParam)}" style="flex:1" class="name">${escapeHtml(c.name)}</a><div class="count">${counts[c.id]||0}</div>`;
-    list.appendChild(div);
+    const link=document.createElement('a');
+    link.className='cat'+(String(urlCat)===String(c.id)?' active':'');
+    link.dataset.id=c.id;
+    link.href='?cat='+c.id+'&q='+encodeURIComponent(qParam);
+    link.innerHTML=`<span class="name">${escapeHtml(c.name)}</span><span class="count">${counts[c.id]||0}</span>`;
+    list.appendChild(link);
   });
 }
 function fmt(ts){ const d=new Date(ts*1000); const p=n=>String(n).padStart(2,'0'); return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`; }


### PR DESCRIPTION
## Summary
- make the category list entries full anchors so clicking anywhere triggers the filter and update the sidebar refresh helper accordingly
- rework the mind map mobile toolbar layout and touch handling so pinch zooming and controls behave smoothly on phones
- simplify button styling across pages to remove the glowing shimmer effect

## Testing
- php -l memo.php

------
https://chatgpt.com/codex/tasks/task_e_68d9a86c085883289c1c439f9def8575