### PR TITLE
Refine mind map editor layout with dock toolbar

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -824,12 +824,11 @@ if ($view === 'new') {
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.18);opacity:.65;pointer-events:none}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.92));border:1px solid rgba(201,168,106,.28);border-radius:var(--r-lg);padding:24px;box-shadow:var(--shadow-1);backdrop-filter:blur(14px)}
       .card::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-lg) - 4px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 34px rgba(227,198,139,.08);pointer-events:none;opacity:.9}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 0 0 0 rgba(227,198,139,0);overflow:hidden}
-      .btn::after{content:"";position:absolute;inset:-1px;border-radius:inherit;background:linear-gradient(90deg,transparent,rgba(227,198,139,.18),transparent);transform:translateX(-100%);animation:scanline 2.8s linear infinite;opacity:.8}
-      @keyframes scanline{to{transform:translateX(100%)}}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 10px 30px rgba(0,0,0,.45),0 0 24px rgba(227,198,139,.16);border-color:rgba(227,198,139,.65)}
+      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .btn::after{content:none}
+      .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
       .btn:active{transform:translateY(0);background:rgba(21,26,30,.94);border-color:var(--gold-700)}
-      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));color:var(--gold-400);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 16px 32px rgba(0,0,0,.55)}
+      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));color:var(--gold-400);box-shadow:none}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 2px rgba(227,198,139,.25)}
       .row{display:grid;grid-template-columns:2fr 1fr auto;gap:16px;margin-bottom:20px;align-items:center}
       .row input,.row select{padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 15px/1.4 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
@@ -1200,13 +1199,12 @@ if ($view === 'item' && isset($_GET['id']) && ctype_digit((string)$_GET['id'])) 
       h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
       .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px;position:relative;z-index:0}
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.2);opacity:.6;pointer-events:none}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);overflow:hidden}
-      .btn::after{content:"";position:absolute;inset:-1px;border-radius:inherit;background:linear-gradient(90deg,transparent,rgba(227,198,139,.18),transparent);transform:translateX(-100%);animation:scanline 2.8s linear infinite;opacity:.8}
-      @keyframes scanline{to{transform:translateX(100%)}}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 10px 30px rgba(0,0,0,.45),0 0 24px rgba(227,198,139,.16);border-color:rgba(227,198,139,.65)}
+      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.82);color:var(--gold-400);cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .btn::after{content:none}
+      .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
       .btn:active{transform:translateY(0);border-color:var(--gold-700);background:rgba(21,26,30,.94)}
-      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));box-shadow:0 0 0 1px rgba(227,198,139,.25),0 16px 32px rgba(0,0,0,.55)}
-      .btn.danger{color:#F8E6E6;border-color:rgba(209,75,75,.55);box-shadow:0 0 24px rgba(209,75,75,.32)}
+      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.24));box-shadow:none}
+      .btn.danger{color:#F8E6E6;border-color:rgba(209,75,75,.55);box-shadow:none}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.94));border:1px solid rgba(201,168,106,.32);border-radius:24px;padding:28px;box-shadow:var(--shadow-1);backdrop-filter:blur(16px)}
       .card::before{content:"";position:absolute;inset:12px;border-radius:calc(24px - 6px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 40px rgba(227,198,139,.1);pointer-events:none}
@@ -1641,45 +1639,90 @@ if ($view === 'map_edit') {
       .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.24;animation:scan 12s linear infinite}
       @keyframes scan{0%{transform:translateY(-100%)}100%{transform:translateY(100%)}}
       a{color:inherit;text-decoration:none}
-      .layout{display:grid;grid-template-columns:360px 1fr;min-height:100vh;position:relative;gap:0}
-      @media (max-width:1180px){.layout{grid-template-columns:320px 1fr}}
-      @media (max-width:1024px){.layout{grid-template-columns:1fr}}
-      .sidebar{position:relative;z-index:90;display:flex;flex-direction:column;gap:20px;padding:32px;border-right:1px solid rgba(201,168,106,.28);background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));box-shadow:var(--shadow-1);backdrop-filter:blur(18px)}
-      .sidebar::before{content:"";position:absolute;inset:14px;border-radius:var(--r-lg);border:1px solid rgba(201,168,106,.18);opacity:.6;pointer-events:none}
-      .sidebar h1{margin:0;font:600 24px/1.4 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.08em;text-transform:uppercase}
-      .sidebar .meta{color:var(--text-muted);font:500 13px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase}
-      .sidebar label{display:block;margin-bottom:6px;font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--text-muted);letter-spacing:.14em;text-transform:uppercase}
-      .sidebar input,.sidebar select{width:100%;padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.76);color:var(--text-strong);font:500 15px/1.5 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
-      .sidebar input:focus,.sidebar select:focus{border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.16),inset 0 0 0 1px rgba(227,198,139,.22);outline:none}
-      .actions,.toolbar{display:flex;flex-wrap:wrap;gap:12px;margin-top:6px}
-      .sidebar button,.map-toolbar button,.mobile-toolbar button{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);overflow:hidden}
-      .sidebar button::after,.map-toolbar button::after,.mobile-toolbar button::after{content:"";position:absolute;inset:-1px;border-radius:inherit;background:linear-gradient(90deg,transparent,rgba(227,198,139,.18),transparent);transform:translateX(-100%);animation:scanline 2.8s linear infinite;opacity:.75}
-      @keyframes scanline{to{transform:translateX(100%)}}
-      .sidebar button:hover,.map-toolbar button:hover,.mobile-toolbar button:hover{transform:translateY(-2px);box-shadow:0 12px 30px rgba(0,0,0,.45),0 0 24px rgba(227,198,139,.16);border-color:rgba(227,198,139,.65)}
-      .sidebar button:active,.map-toolbar button:active,.mobile-toolbar button:active{transform:translateY(0);border-color:var(--gold-700);background:rgba(21,26,30,.92)}
-      .sidebar button.acc,.mobile-toolbar button.primary{background:linear-gradient(135deg,rgba(201,168,106,.2),rgba(170,140,84,.28));color:var(--bg-void);box-shadow:0 0 0 1px rgba(227,198,139,.28),0 18px 34px rgba(0,0,0,.55)}
-      .sidebar button.danger,.mobile-toolbar button.danger{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:0 0 24px rgba(209,75,75,.32)}
-      .btn-like{display:inline-flex;align-items:center;justify-content:center;width:100%;padding:12px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.4);background:rgba(12,16,18,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em;cursor:pointer;transition:all var(--transition)}
-      .btn-like.danger{border-color:rgba(209,75,75,.52);color:#F6D6D6;background:rgba(35,10,14,.86);box-shadow:0 20px 38px rgba(209,75,75,.32)}
-      .inspector{margin-top:8px;padding:18px;border-radius:var(--r-md);border:1px solid rgba(201,168,106,.3);background:rgba(15,19,22,.82);box-shadow:var(--shadow-1);display:grid;gap:16px}
-      .inspector h2{margin:0 0 6px;font:600 16px/1.4 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.08em;text-transform:uppercase}
-      .field{display:grid;gap:8px}
+      .mind-shell{min-height:100vh;display:flex;flex-direction:column;align-items:center;padding-bottom:140px}
+      .editor-pane{position:relative;width:100%;max-width:1440px;margin:0 auto;flex:1;display:flex;flex-direction:column;padding:32px clamp(24px,5vw,48px) 0}
+      .mind-hud{display:flex;align-items:flex-start;justify-content:space-between;gap:24px;margin-bottom:18px;background:linear-gradient(180deg,rgba(21,26,30,.92),rgba(15,19,22,.94));border:1px solid rgba(201,168,106,.28);border-radius:22px;padding:18px 22px;box-shadow:0 18px 40px rgba(0,0,0,.55),inset 0 0 0 1px rgba(201,168,106,.08);backdrop-filter:blur(14px)}
+      .hud-left{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
+      .hud-back{display:inline-flex;align-items:center;gap:6px;padding:10px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;transition:border-color var(--transition),transform var(--transition);touch-action:manipulation}
+      .hud-back:hover{transform:translateY(-1px);border-color:rgba(227,198,139,.6)}
+      .hud-back:active{transform:translateY(0);border-color:var(--gold-700)}
+      .hud-meta{display:flex;flex-direction:column;gap:6px;min-width:220px}
+      .hud-meta input{padding:12px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.7);color:var(--text-strong);font:600 18px/1.4 'Cinzel','Noto Serif SC',serif;letter-spacing:.06em;text-transform:uppercase;transition:border-color var(--transition),box-shadow var(--transition)}
+      .hud-meta input:focus{border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.18);outline:none}
+      .hud-info{color:var(--text-muted);font:500 12px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase}
+      .hud-right{display:flex;align-items:center;gap:12px;margin-left:auto}
+      .mind-stage{position:relative;flex:1;min-height:calc(100vh - 220px)}
+      #jsmind-container{position:absolute;inset:0;width:100%;height:100%;overflow:hidden;background:linear-gradient(160deg,rgba(21,26,30,.82),rgba(10,12,14,.94));box-shadow:inset 0 0 48px rgba(0,0,0,.6);touch-action:none}
+      .map-toolbar{position:absolute;top:24px;right:24px;display:flex;gap:12px;z-index:60}
+      .map-toolbar button{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.38);background:rgba(12,16,18,.86);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),border-color var(--transition);touch-action:manipulation}
+      .map-toolbar button:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.65)}
+      .map-toolbar button:active{transform:translateY(0);border-color:var(--gold-700)}
+      @media (max-width:820px){.map-toolbar{display:none}}
       .chips-preview{display:flex;gap:8px;flex-wrap:wrap;min-height:26px}
       .chips-preview .chip{display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:999px;border:1px solid rgba(201,168,106,.3);background:rgba(21,26,30,.82);color:var(--text-dim);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase}
       .chips-preview .empty{color:var(--text-muted);font-size:12px}
-      .tips{font:400 13px/1.8 'Noto Sans SC','Inter',sans-serif;color:var(--text-muted)}
-      .tips strong{color:var(--gold-500);letter-spacing:.08em}
-      .tips code{padding:2px 6px;border-radius:6px;background:rgba(21,26,30,.9);border:1px solid rgba(201,168,106,.26);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif}
-      .editor-pane{position:relative;background:rgba(6,10,12,.35)}
-      #jsmind-container{position:relative;width:100%;height:100vh;height:100dvh;overflow:hidden;background:linear-gradient(160deg,rgba(21,26,30,.82),rgba(10,12,14,.94));box-shadow:inset 0 0 48px rgba(0,0,0,.6)}
+      .dock-wrap{position:fixed;left:50%;bottom:clamp(18px,4vh,32px);transform:translateX(-50%);z-index:95;pointer-events:none}
+      .dock{pointer-events:auto;display:flex;align-items:center;gap:10px;padding:12px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.86));border:1px solid rgba(201,168,106,.28);border-radius:28px;box-shadow:0 18px 48px rgba(0,0,0,.55),0 0 28px rgba(227,198,139,.12) inset;backdrop-filter:blur(12px);transition:box-shadow var(--transition)}
+      .dock-btn{position:relative;isolation:isolate;display:grid;place-items:center;width:88px;height:56px;border-radius:18px;border:1px solid rgba(201,168,106,.38);background:rgba(201,168,106,.08);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition);touch-action:manipulation;outline:none;--dock-scale:1;--dock-translate:0;transform:translateY(var(--dock-translate)) scale(var(--dock-scale))}
+      .dock-btn svg{width:22px;height:22px}
+      .dock-btn .label{position:absolute;bottom:6px;font:500 12px/1 'Inter','Noto Sans SC',sans-serif;color:var(--text-dim);letter-spacing:.08em;pointer-events:none}
+      .dock-btn:hover{--dock-translate:-2px;border-color:var(--gold-500);background:rgba(201,168,106,.14)}
+      .dock-btn:active{--dock-translate:0;border-color:var(--gold-700)}
+      .dock-btn:focus-visible{box-shadow:0 0 0 3px rgba(227,198,139,.22),0 0 0 5px rgba(75,195,209,.28)}
+      .dock-btn.danger{color:#f6d6d6;border-color:rgba(209,75,75,.45);background:rgba(209,75,75,.12)}
+      .dock-btn.danger:hover{background:rgba(209,75,75,.18);border-color:rgba(209,75,75,.62)}
+      .dock-btn.ghost{background:rgba(201,168,106,.05)}
+      .dock-sep{width:10px;height:42px;border-right:1px solid rgba(201,168,106,.22);opacity:.7}
+      .dock-more{position:relative}
+      .dock-menu{position:absolute;bottom:64px;right:0;min-width:176px;padding:10px;margin:0;list-style:none;background:linear-gradient(180deg,rgba(21,26,30,.96),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.28);border-radius:16px;box-shadow:0 22px 48px rgba(0,0,0,.55);display:none}
+      .dock-menu[aria-hidden="true"]{display:none}
+      .dock-more[aria-expanded="true"] .dock-menu{display:block}
+      .dock-menu li{margin:0;padding:0}
+      .dock-menu button{width:100%;padding:10px 12px;border-radius:12px;border:0;background:transparent;color:var(--text-strong);font:600 13px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;text-align:left;cursor:pointer;transition:background-color var(--transition),color var(--transition)}
+      .dock-menu button:hover{background:rgba(201,168,106,.12);color:var(--gold-400)}
+      .dock[data-fisheye="on"] .dock-btn{transform-origin:50% 60%}
+      .node-popover{position:fixed;z-index:110;min-width:280px;max-width:360px;background:linear-gradient(180deg,rgba(21,26,30,.96),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.28);border-radius:18px;box-shadow:0 28px 60px rgba(0,0,0,.55),inset 0 0 24px rgba(227,198,139,.08);padding:18px 20px;display:flex;flex-direction:column;gap:14px;backdrop-filter:blur(16px)}
+      .node-popover[hidden]{display:none}
+      .node-popover__header{display:flex;align-items:center;justify-content:space-between;gap:12px}
+      .node-popover__header h2{margin:0;font:600 16px/1.4 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.08em;text-transform:uppercase}
+      .node-popover__close{border:0;background:transparent;color:var(--text-dim);font-size:22px;cursor:pointer;padding:6px;border-radius:10px;transition:color var(--transition),background-color var(--transition)}
+      .node-popover__close:hover{color:var(--gold-400);background:rgba(201,168,106,.12)}
+      .node-popover__body{display:grid;gap:12px}
+      .node-popover__body .row{display:grid;gap:8px}
+      .node-popover__body label{font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--text-muted);letter-spacing:.14em;text-transform:uppercase}
+      .node-popover__body input,.node-popover__body select{width:100%;padding:12px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.74);color:var(--text-strong);font:500 14px/1.5 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
+      .node-popover__body input:focus,.node-popover__body select:focus{border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.18);outline:none}
+      .node-popover__actions{display:flex;justify-content:flex-end;gap:10px}
+      .btn-popover{padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.78);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em;text-transform:uppercase;cursor:pointer;transition:transform var(--transition),border-color var(--transition)}
+      .btn-popover:hover{transform:translateY(-1px);border-color:rgba(227,198,139,.6)}
+      .btn-popover.primary{background:linear-gradient(135deg,rgba(201,168,106,.24),rgba(170,140,84,.28));color:var(--bg-void)}
+      .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+      .save-tip{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;color:var(--gold-400);text-transform:uppercase;display:none}
+      .save-tip.dirty{color:var(--accent-crimson)}
+      .save-tip.show{display:inline-flex}
+      @media (max-width:960px){
+        .editor-pane{padding:24px 20px 0}
+        .mind-hud{flex-direction:column;align-items:flex-start;gap:16px}
+        .dock{gap:8px;padding:10px}
+        .dock-btn{width:74px;height:52px}
+        .dock-btn .label{font-size:11px}
+      }
+      @media (prefers-reduced-motion: reduce){
+        .dock-btn{transition:none}
+        .dock[data-fisheye="on"] .dock-btn{transform:none !important}
+      }
       .mind-background{position:absolute;inset:0;background:radial-gradient(circle at 18% 24%,rgba(227,198,139,.08),transparent 55%),radial-gradient(circle at 68% 12%,rgba(227,198,139,.05),transparent 60%),linear-gradient(120deg,rgba(201,168,106,.06),transparent 65%);pointer-events:none;opacity:.8}
       .mind-viewport,.mind-links{position:absolute;top:0;left:0;transform-origin:0 0}
-      .mind-links{pointer-events:none;filter:drop-shadow(0 0 8px rgba(227,198,139,.25))}
-      .mind-links path{fill:none;stroke:var(--fiber);stroke-width:2.2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:18 32;animation:fiberFlow 8s linear infinite}
-      .mind-links path[data-status="doing"]{stroke:var(--gold-400);stroke-dasharray:12 24;animation:fiberPulse 3s linear infinite}
-      .mind-links path[data-status="done"]{stroke:rgba(201,168,106,.5);opacity:.8;stroke-dasharray:20 36}
-      @keyframes fiberFlow{0%{stroke-dashoffset:0;opacity:.85}100%{stroke-dashoffset:-480;opacity:1}}
-      @keyframes fiberPulse{0%{stroke-dashoffset:0;opacity:.9}100%{stroke-dashoffset:-320;opacity:1}}
+      .mind-links{pointer-events:none;overflow:visible}
+      .mind-links .trace-group{pointer-events:none}
+      .mind-links .trace{fill:none;stroke-linecap:round;stroke-linejoin:bevel}
+      .mind-links .trace.shadow{stroke:rgba(122,94,54,.55);stroke-width:2.1;opacity:.65;filter:url(#mindSoftGlow)}
+      .mind-links .trace.core{stroke:url(#mindGoldTrace);stroke-width:1.6;filter:url(#mindSoftGlow)}
+      .mind-links .trace.highlight{stroke:rgba(255,242,218,.32);stroke-width:0.8}
+      .mind-links .trace-group[data-status="doing"] .trace.shadow{stroke:rgba(36,194,160,.42);opacity:.7}
+      .mind-links .trace-group[data-status="doing"] .trace.highlight{stroke:rgba(207,250,234,.4)}
+      .mind-links .trace-group[data-status="done"] .trace.core{opacity:.78}
+      .mind-links .trace-group[data-status="done"] .trace.highlight{opacity:.28}
       .mind-nodes{position:absolute;top:0;left:0}
       .jsmind-node{position:absolute;display:flex;flex-direction:column;align-items:flex-start;gap:10px;padding:18px 20px;border-radius:var(--r-md);color:var(--text-strong);font:600 14px/1.5 'Inter','Noto Sans SC',sans-serif;min-width:170px;max-width:320px;background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));border:1.6px solid rgba(201,168,106,.32);box-shadow:0 20px 48px rgba(0,0,0,.58),0 0 30px rgba(227,198,139,.12);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),filter var(--transition);backdrop-filter:blur(12px);letter-spacing:.04em}
       .jsmind-node::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-md) - 4px);border:1px solid rgba(201,168,106,.22);opacity:.7;pointer-events:none;animation:nodeGlow 9s ease-in-out infinite}
@@ -1700,24 +1743,7 @@ if ($view === 'map_edit') {
       .jsmind-node.status-done{border-color:rgba(201,168,106,.28);filter:saturate(.82);opacity:.9}
       .map-toolbar{position:absolute;top:24px;right:24px;display:flex;gap:12px;z-index:60}
       .map-toolbar button{padding:10px 14px}
-      .mobile-toolbar{position:fixed;left:50%;bottom:26px;transform:translateX(-50%);display:flex;gap:10px;background:rgba(12,16,18,.88);border:1px solid rgba(201,168,106,.28);border-radius:999px;padding:10px 16px;box-shadow:0 28px 60px rgba(0,0,0,.55);backdrop-filter:blur(16px);z-index:80}
-      .mobile-toolbar button{min-width:70px;padding:10px 16px}
       @media (max-width:820px){.map-toolbar{display:none}}
-      .mobile-save-status{position:fixed;left:50%;bottom:90px;transform:translateX(-50%);padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.34);background:rgba(21,26,30,.9);color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;box-shadow:0 18px 44px rgba(0,0,0,.55);backdrop-filter:blur(14px);opacity:0;pointer-events:none;transition:opacity var(--t) ease;z-index:85}
-      .mobile-save-status.show{opacity:1}
-      .mobile-save-status.state-success{border-color:rgba(36,194,160,.42);color:#CFFAEA;box-shadow:0 0 28px rgba(36,194,160,.32)}
-      .mobile-save-status.state-error{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:0 0 28px rgba(209,75,75,.32)}
-      .sidebar-toggle{position:absolute;top:22px;left:22px;padding:10px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.86);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;display:none;z-index:95;box-shadow:0 12px 28px rgba(0,0,0,.45)}
-      @media (max-width:1024px){
-        .sidebar{position:fixed;left:0;top:0;bottom:0;width:min(86vw,360px);transform:translateX(-105%);transition:transform var(--transition);border-right:1px solid rgba(201,168,106,.28);border-radius:0 24px 24px 0}
-        body.sidebar-open .sidebar{transform:translateX(0)}
-        .sidebar-toggle{display:inline-flex;align-items:center;gap:8px}
-      }
-      .sidebar-backdrop{display:none}
-      @media (max-width:1024px){
-        .sidebar-backdrop{position:fixed;inset:0;background:rgba(8,10,12,.65);backdrop-filter:blur(10px);z-index:80;opacity:0;transition:opacity var(--t) ease}
-        body.sidebar-open .sidebar-backdrop{display:block;opacity:1}
-      }
       .badge{display:inline-flex;align-items:center;padding:4px 10px;border-radius:999px;border:1px dashed rgba(201,168,106,.32);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase}
       .save-tip{display:none;font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;color:var(--gold-400);text-transform:uppercase}
       .save-tip.dirty{color:var(--accent-crimson)}
@@ -1728,113 +1754,157 @@ if ($view === 'map_edit') {
   </head>
   <body>
     <div class="scanlines" aria-hidden="true"></div>
-    <div class="layout">
-      <aside class="sidebar">
-        <div style="display:flex;gap:10px;align-items:center;justify-content:space-between;flex-wrap:wrap">
-          <h1>思维导图编辑器</h1>
-          <a href="<?= htmlspecialchars($_SERVER['PHP_SELF'].'?view=maps') ?>" style="font-size:13px;color:var(--text-dim)">← 导图库</a>
-        </div>
-        <div class="meta">ID：<?php echo $mind['id'] ?: '新建'; ?> · 最近保存：<?php echo dt((int)$mind['updated_at']); ?></div>
-        <label for="map-title">导图标题</label>
-        <input id="map-title" value="<?php echo h($mind['title']); ?>" placeholder="输入导图标题">
-        <div class="actions">
-          <button id="btn-save" class="acc">💾 保存</button>
-          <button id="btn-export-json">⬇️ 导出 JSON</button>
-          <button id="btn-import-json">⬆️ 导入 JSON</button>
-          <input id="import-input" type="file" accept="application/json" style="display:none">
-        </div>
-        <div class="toolbar">
-          <button id="btn-add-sibling">↕ 同级节点 (Enter)</button>
-          <button id="btn-add-child">→ 子级节点 (Tab)</button>
-          <button id="btn-delete" class="danger">🗑 删除节点 (Del)</button>
-        </div>
-        <div class="toolbar">
-          <button id="btn-attach-file">📎 上传附件</button>
-          <button id="btn-attach-link">🔗 新增链接</button>
-          <input id="attach-file-input" type="file" accept="image/*,application/pdf,application/zip,application/x-zip-compressed,text/plain,text/markdown,text/csv,application/json,video/*" style="display:none">
-        </div>
-        <section class="inspector" id="node-inspector">
-          <h2>节点信息</h2>
-          <div class="field">
-            <label for="node-type">类型</label>
-            <select id="node-type">
-              <option value="idea">💡 创意</option>
-              <option value="task">✅ 任务</option>
-              <option value="document">📄 文档</option>
-              <option value="media">🖼 媒体</option>
-              <option value="decision">🧭 决策</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="node-status">状态</label>
-            <select id="node-status">
-              <option value="backlog">待计划</option>
-              <option value="doing">进行中</option>
-              <option value="done">已完成</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="node-priority">优先级</label>
-            <select id="node-priority">
-              <option value="normal">普通</option>
-              <option value="high">高</option>
-              <option value="low">低</option>
-            </select>
-          </div>
-          <div class="field">
-            <label for="node-owner">负责人</label>
-            <input id="node-owner" type="text" placeholder="输入姓名或团队">
-          </div>
-          <div class="field">
-            <label for="node-tags">标签</label>
-            <input id="node-tags" type="text" placeholder="用逗号分隔多个标签">
-            <div class="chips-preview" id="node-tags-preview"><span class="empty">暂无标签</span></div>
-          </div>
-        </section>
-        <div class="toolbar">
-          <button id="btn-fit">🧭 自适应视图</button>
-          <button id="btn-center">◎ 居中</button>
-          <button id="btn-zoom-in">＋ 放大</button>
-          <button id="btn-zoom-out">－ 缩小</button>
-        </div>
-        <div class="tips">
-          <strong>快捷键</strong><br>
-          <code>Enter</code> 同级 · <code>Tab</code> 子级 · <code>Shift+Tab</code> 升级 · <code>Del</code> 删除 · <code>F2</code> 重命名 · <code>Ctrl/Cmd+Z</code> 撤销<br>
-          鼠标中键/空格拖拽 · 滚轮缩放 · 按住 <code>Alt</code> 拖动可复制节点。<br>
-          将图片、PDF、ZIP、文本或视频文件拖到节点上即可为该节点附加附件，超过 15MB 或不在白名单内的文件将被拒绝。
-        </div>
-        <div>
-          <span class="badge">提示</span>
-          <div class="meta" style="margin-top:6px">保存数据存入 SQLite，可多端共享；导出 JSON 可用于备份或导入其他工具（如 FreeMind、XMind）。</div>
-        </div>
-        <div class="save-tip" id="save-state">保存成功</div>
-        <?php if ($mind['id']): ?>
-          <form method="post" onsubmit="return confirm('确认删除该导图？');" style="margin-top:auto">
-            <input type="hidden" name="action" value="delete_mindmap">
-            <input type="hidden" name="id" value="<?php echo $mind['id']; ?>">
-            <button class="btn-like danger btn-block">删除导图</button>
-          </form>
-        <?php endif; ?>
-      </aside>
+    <svg width="0" height="0" aria-hidden="true" focusable="false" style="position:absolute">
+      <defs>
+        <linearGradient id="mindGoldTrace" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stop-color="#E3C68B" />
+          <stop offset="50%" stop-color="#C9A86A" />
+          <stop offset="100%" stop-color="#AA8C54" />
+        </linearGradient>
+        <filter id="mindSoftGlow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="0.6" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+    </svg>
+    <div class="mind-shell">
       <main class="editor-pane">
-        <button type="button" id="sidebar-toggle" class="sidebar-toggle" aria-expanded="false">☰ 操作</button>
-        <div id="jsmind-container" data-map-id="<?php echo $mind['id']; ?>"></div>
-        <div class="map-toolbar">
-          <button id="btn-collapse">折叠/展开节点</button>
-          <button id="btn-fit-floating">自适应视图</button>
+        <header class="mind-hud">
+          <div class="hud-left">
+            <a class="hud-back" href="<?= htmlspecialchars($_SERVER['PHP_SELF'].'?view=maps') ?>" aria-label="返回导图库">← 导图库</a>
+            <div class="hud-meta">
+              <input id="map-title" value="<?php echo h($mind['title']); ?>" placeholder="输入导图标题" aria-label="导图标题">
+              <div class="hud-info">ID：<?php echo $mind['id'] ?: '新建'; ?> · 最近保存：<?php echo dt((int)$mind['updated_at']); ?></div>
+            </div>
+          </div>
+          <div class="hud-right">
+            <div class="save-tip" id="save-state" role="status" aria-live="polite">保存成功</div>
+          </div>
+        </header>
+        <div class="mind-stage">
+          <div id="jsmind-container" data-map-id="<?php echo $mind['id']; ?>"></div>
+          <div class="map-toolbar">
+            <button id="btn-collapse">折叠/展开节点</button>
+            <button id="btn-fit-floating">自适应视图</button>
+          </div>
         </div>
-        <div class="mobile-toolbar" id="mobile-toolbar">
-          <button data-action="save" class="primary">保存</button>
-          <button data-action="add-sibling">同级</button>
-          <button data-action="add-child">子级</button>
-          <button data-action="attach-file">附件</button>
-          <button data-action="attach-link">链接</button>
-          <button data-action="delete" class="danger">删除</button>
-        </div>
-        <div class="mobile-save-status" id="mobile-save-status" role="status" aria-live="polite"></div>
       </main>
+      <div class="dock-wrap" role="toolbar" aria-label="思维导图操作工具栏">
+        <nav class="dock" id="mind-dock">
+          <button class="dock-btn" data-action="save" title="保存 (Ctrl+S)" aria-label="保存">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4h10l4 4v12H5zM7 4v6h8V4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+            <span class="label">保存</span>
+          </button>
+          <button class="dock-btn" data-action="sibling" title="新增同级 (Enter)" aria-label="新增同级">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12h16M12 4v16" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+            <span class="label">同级</span>
+          </button>
+          <button class="dock-btn" data-action="child" title="新增子级 (Tab)" aria-label="新增子级">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 6h8v4H5zM13 8h6M5 14h8v4H5z" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+            <span class="label">子级</span>
+          </button>
+          <button class="dock-btn" data-action="attach" title="上传附件" aria-label="上传附件">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 12v5a4 4 0 0 0 8 0V7a3 3 0 0 0-6 0v8a2 2 0 0 0 4 0V9" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+            <span class="label">附件</span>
+          </button>
+          <button class="dock-btn" data-action="link" title="新增链接" aria-label="新增链接">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 15l-2 2a4 4 0 0 1-6-6l2-2m14 0l2 2a4 4 0 0 1-6 6l-2-2M7 13l10-10" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+            <span class="label">链接</span>
+          </button>
+          <button class="dock-btn danger" data-action="delete" title="删除 (Del)" aria-label="删除" aria-describedby="dock-danger-hint">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h16M9 7V4h6v3M9 10v8M15 10v8" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>
+            <span class="label">删除</span>
+          </button>
+          <div class="dock-sep" aria-hidden="true"></div>
+          <div class="dock-more">
+            <button class="dock-btn ghost" id="dock-more-toggle" aria-haspopup="menu" aria-expanded="false" title="更多">
+              <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></svg>
+              <span class="label">更多</span>
+            </button>
+            <ul class="dock-menu" id="mind-dock-menu" role="menu">
+              <li role="menuitem">
+                <button type="button" data-action="import" id="btn-import-json">导入 JSON</button>
+              </li>
+              <li role="menuitem">
+                <button type="button" data-action="export" id="btn-export-json">导出 JSON</button>
+              </li>
+              <li role="menuitem">
+                <button type="button" data-action="toggle-fold" id="btn-collapse-menu">折叠/展开</button>
+              </li>
+              <li role="menuitem">
+                <button type="button" data-action="fit-view" id="btn-fit">自适应视图</button>
+              </li>
+              <li role="menuitem">
+                <button type="button" data-action="center" id="btn-center">居中</button>
+              </li>
+              <li role="menuitem">
+                <button type="button" data-action="zoom-in" id="btn-zoom-in">放大</button>
+              </li>
+              <li role="menuitem">
+                <button type="button" data-action="zoom-out" id="btn-zoom-out">缩小</button>
+              </li>
+            </ul>
+          </div>
+        </nav>
+        <p id="dock-danger-hint" class="sr-only">此操作不可撤销，请谨慎。</p>
+      </div>
     </div>
-    <div class="sidebar-backdrop" id="sidebar-backdrop" hidden></div>
+    <div class="node-popover" id="node-inspector" hidden>
+      <div class="node-popover__header">
+        <h2>节点属性</h2>
+        <button type="button" class="node-popover__close" aria-label="关闭节点属性">×</button>
+      </div>
+      <div class="node-popover__body">
+        <div class="row">
+          <label for="node-title">标题</label>
+          <input id="node-title" type="text" placeholder="输入节点标题">
+        </div>
+        <div class="row">
+          <label for="node-type">类型</label>
+          <select id="node-type">
+            <option value="idea">💡 创意</option>
+            <option value="task">✅ 任务</option>
+            <option value="document">📄 文档</option>
+            <option value="media">🖼 媒体</option>
+            <option value="decision">🧭 决策</option>
+          </select>
+        </div>
+        <div class="row">
+          <label for="node-status">状态</label>
+          <select id="node-status">
+            <option value="backlog">待计划</option>
+            <option value="doing">进行中</option>
+            <option value="done">已完成</option>
+          </select>
+        </div>
+        <div class="row">
+          <label for="node-priority">优先级</label>
+          <select id="node-priority">
+            <option value="normal">普通</option>
+            <option value="high">高</option>
+            <option value="low">低</option>
+          </select>
+        </div>
+        <div class="row">
+          <label for="node-owner">负责人</label>
+          <input id="node-owner" type="text" placeholder="输入姓名或团队">
+        </div>
+        <div class="row">
+          <label for="node-tags">标签</label>
+          <input id="node-tags" type="text" placeholder="用逗号分隔多个标签">
+          <div class="chips-preview" id="node-tags-preview"><span class="empty">暂无标签</span></div>
+        </div>
+      </div>
+      <div class="node-popover__actions">
+        <button type="button" class="btn-popover" data-popover="cancel">取消</button>
+        <button type="button" class="btn-popover primary" data-popover="apply">保存</button>
+      </div>
+    </div>
+    <input id="import-input" type="file" accept="application/json" hidden>
+    <input id="attach-file-input" type="file" accept="image/*,application/pdf,application/zip,application/x-zip-compressed,text/plain,text/markdown,text/csv,application/json,video/*" hidden>
     <script>
       (function(){
       const DOUBLE_TAP_WINDOW=320;
@@ -1859,6 +1929,84 @@ if ($view === 'map_edit') {
       const TYPE_ACCENT_MAP=NODE_TYPES.reduce((acc,item)=>{acc[item.value]=item.accent;return acc;},{});
       const isCompactViewport=()=>window.matchMedia('(max-width: 900px)').matches;
       let lastTapInfo={id:null,time:0};
+      const TRACE_GRID=8;
+      const TRACE_CHAMFER=3;
+      const nearlyEqual=(a,b)=>Math.abs(a-b)<0.5;
+      function alignToTraceGrid(value){
+        return Math.round(value/TRACE_GRID)*TRACE_GRID;
+      }
+      function buildTraceRoute(start,end,directionHint=1){
+        if(!start || !end){ return []; }
+        const points=[{x:start.x,y:start.y}];
+        const rawDx=end.x-start.x;
+        const absDx=Math.abs(rawDx);
+        const direction=(absDx<TRACE_GRID*0.5)
+          ? (directionHint>=0?1:-1)
+          : (rawDx>=0?1:-1);
+        const MIN_LEAD=TRACE_GRID*3;
+        let midX;
+        if(absDx<TRACE_GRID*0.25){
+          midX=start.x + direction*MIN_LEAD;
+        }else if(absDx<=TRACE_GRID*3){
+          const halfSpan=absDx/2;
+          midX=start.x + direction*Math.max(MIN_LEAD, halfSpan);
+        }else{
+          const maxLead=Math.max(MIN_LEAD, absDx - TRACE_GRID*2);
+          let lead=absDx*0.45;
+          lead=Math.min(Math.max(MIN_LEAD, lead), maxLead);
+          midX=start.x + direction*lead;
+        }
+        midX=alignToTraceGrid(midX);
+        const viaY=alignToTraceGrid(end.y);
+        points.push({x:midX,y:start.y});
+        if(!nearlyEqual(viaY,start.y)){
+          points.push({x:midX,y:viaY});
+        }
+        points.push({x:end.x,y:end.y});
+        const cleaned=[];
+        for(const pt of points){
+          if(!cleaned.length){ cleaned.push(pt); continue; }
+          const prev=cleaned[cleaned.length-1];
+          if(nearlyEqual(prev.x, pt.x) && nearlyEqual(prev.y, pt.y)){
+            continue;
+          }
+          cleaned.push(pt);
+        }
+        return cleaned;
+      }
+      function buildChamferedPath(points,chamfer){
+        if(!Array.isArray(points) || points.length<2) return '';
+        let d=`M${points[0].x} ${points[0].y}`;
+        for(let i=1;i<points.length;i++){
+          const current=points[i];
+          const prev=points[i-1];
+          const next=i+1<points.length ? points[i+1] : null;
+          if(next){
+            const prevVec={x:current.x-prev.x,y:current.y-prev.y};
+            const nextVec={x:next.x-current.x,y:next.y-current.y};
+            const prevLen=Math.hypot(prevVec.x,prevVec.y);
+            const nextLen=Math.hypot(nextVec.x,nextVec.y);
+            if(prevLen<0.01 || nextLen<0.01){
+              d+=` L${current.x} ${current.y}`;
+              continue;
+            }
+            const cut=Math.min(chamfer, prevLen/2, nextLen/2);
+            const entry={
+              x:current.x - Math.sign(prevVec.x)*cut,
+              y:current.y - Math.sign(prevVec.y)*cut
+            };
+            const exit={
+              x:current.x + Math.sign(nextVec.x)*cut,
+              y:current.y + Math.sign(nextVec.y)*cut
+            };
+            d+=` L${entry.x} ${entry.y}`;
+            d+=` L${exit.x} ${exit.y}`;
+          }else{
+            d+=` L${current.x} ${current.y}`;
+          }
+        }
+        return d;
+      }
       function normalizeNodeData(value){
         if(!value || typeof value!=='object' || Array.isArray(value)) return {};
         const data=value;
@@ -1920,6 +2068,10 @@ if ($view === 'map_edit') {
           this.selectedId=null;
           this.container.innerHTML='';
           this.container.classList.add('mind-container');
+          this.container.style.touchAction='none';
+          this.container.addEventListener('gesturestart',evt=>evt.preventDefault());
+          this.container.addEventListener('gesturechange',evt=>evt.preventDefault());
+          this.container.addEventListener('gestureend',evt=>evt.preventDefault());
           this.background=document.createElement('div');
           this.background.className='mind-background';
           this.container.appendChild(this.background);
@@ -1946,6 +2098,7 @@ if ($view === 'map_edit') {
           this.linkRegistry=new Map();
           this.resizeObserver=typeof ResizeObserver!=='undefined'?new ResizeObserver(entries=>this.handleNodeResize(entries)):null;
           this.setupPan();
+          this.setupTouchGuards();
         }
         setupPan(){
           const updatePinchBaseline=()=>{
@@ -1978,6 +2131,9 @@ if ($view === 'map_edit') {
               return;
             }
             this.activePointers.set(evt.pointerId,{x:evt.clientX,y:evt.clientY});
+            if(isTouch && (this.activePointers.size>=2 || !onNode)){
+              evt.preventDefault();
+            }
             if(this.activePointers.size>=2){
               for(const id of this.activePointers.keys()){
                 try{ this.container.setPointerCapture(id); }catch(_){ }
@@ -2016,6 +2172,9 @@ if ($view === 'map_edit') {
                 this.offsetY=centerY - pinch.originY*this.scale;
                 this.applyTransform();
                 return;
+              }
+              if(this.dragState && this.dragState.pointerId===evt.pointerId){
+                evt.preventDefault();
               }
             }
             if(!this.dragState || evt.pointerId!==this.dragState.pointerId) return;
@@ -2188,6 +2347,60 @@ if ($view === 'map_edit') {
           this.render();
           this.select_node(parent.id);
           this.emit(SimpleMind.event_type.update);
+        }
+        setupTouchGuards(){
+          let lastTapTime=0;
+          let lastTapX=0;
+          let lastTapY=0;
+          let tapTimer=null;
+          const DOUBLE_TAP_DELAY=320;
+          const DOUBLE_TAP_DISTANCE=26;
+          const reset=()=>{
+            if(tapTimer){ clearTimeout(tapTimer); tapTimer=null; }
+            lastTapTime=0;
+          };
+          const isEditableTarget=(target)=>{
+            if(!target || !target.tagName) return false;
+            const tag=target.tagName.toLowerCase();
+            return tag==='input' || tag==='textarea' || tag==='select' || target.isContentEditable===true;
+          };
+          this.container.addEventListener('touchstart',(evt)=>{
+            if(evt.touches.length>1){ reset(); return; }
+            const target=evt.target;
+            if(isEditableTarget(target)){ reset(); return; }
+            const touch=evt.touches[0];
+            const now=performance.now();
+            if(lastTapTime){
+              const delta=now-lastTapTime;
+              const dx=touch.clientX-lastTapX;
+              const dy=touch.clientY-lastTapY;
+              if(delta>0 && delta<=DOUBLE_TAP_DELAY && (dx*dx + dy*dy) <= (DOUBLE_TAP_DISTANCE*DOUBLE_TAP_DISTANCE)){
+                evt.preventDefault();
+                const dblTarget=target || this.container;
+                const dblEvt=new MouseEvent('dblclick',{
+                  bubbles:true,
+                  cancelable:true,
+                  clientX:touch.clientX,
+                  clientY:touch.clientY,
+                });
+                dblTarget.dispatchEvent(dblEvt);
+                reset();
+                return;
+              }
+            }
+            lastTapTime=now;
+            lastTapX=touch.clientX;
+            lastTapY=touch.clientY;
+            if(tapTimer){ clearTimeout(tapTimer); }
+            tapTimer=setTimeout(reset, DOUBLE_TAP_DELAY+60);
+          },{passive:false});
+          this.container.addEventListener('touchend',(evt)=>{
+            if(evt.touches && evt.touches.length>0) return;
+            if(isEditableTarget(evt.target)){ reset(); return; }
+            if(tapTimer){ clearTimeout(tapTimer); }
+            tapTimer=setTimeout(reset, DOUBLE_TAP_DELAY);
+          });
+          this.container.addEventListener('touchcancel', reset);
         }
         toggle_node(id){
           const node=this.nodes.get(id);
@@ -2483,13 +2696,27 @@ if ($view === 'map_edit') {
             this.updateNodePosition(node);
             this.updateAnchors(node);
             if(node.parent){
-              const path=document.createElementNS('http://www.w3.org/2000/svg','path');
-              path.setAttribute('data-from', node.parent.id);
-              path.setAttribute('data-to', node.id);
-              path.setAttribute('data-type', node.data && node.data.type ? node.data.type : 'idea');
-              this.linkLayer.appendChild(path);
-              node.linkPath=path;
-              this.linkRegistry.set(node.id,path);
+              const group=document.createElementNS('http://www.w3.org/2000/svg','g');
+              group.classList.add('trace-group');
+              const shadow=document.createElementNS('http://www.w3.org/2000/svg','path');
+              shadow.classList.add('trace','shadow');
+              const core=document.createElementNS('http://www.w3.org/2000/svg','path');
+              core.classList.add('trace','core');
+              core.setAttribute('stroke','url(#mindGoldTrace)');
+              const highlight=document.createElementNS('http://www.w3.org/2000/svg','path');
+              highlight.classList.add('trace','highlight');
+              group.appendChild(shadow);
+              group.appendChild(core);
+              group.appendChild(highlight);
+              group.dataset.from=node.parent.id;
+              group.dataset.to=node.id;
+              if(node.data && node.data.type){ group.dataset.type=node.data.type; }
+              this.linkLayer.appendChild(group);
+              node.linkGroup=group;
+              node.linkShadow=shadow;
+              node.linkPath=core;
+              node.linkHighlight=highlight;
+              this.linkRegistry.set(node.id,{group,shadow,core,highlight});
               this.updateLinkPath(node);
             }
             if(this.resizeObserver){ this.resizeObserver.observe(node.el); }
@@ -2527,11 +2754,20 @@ if ($view === 'map_edit') {
           const isLeft=node.dir===-1 || node.direction==='left' || node.absX<=parent.absX;
           const start=isLeft ? parent.anchors.left : parent.anchors.right;
           const end=isLeft ? node.anchors.right : node.anchors.left;
-          const horizontalGap=Math.max(60, Math.abs(end.x-start.x)*0.35);
-          const controlX=start.x + (isLeft?-horizontalGap:horizontalGap);
-          const controlY1=start.y;
-          const controlY2=end.y;
-          node.linkPath.setAttribute('d', `M${start.x} ${start.y} C ${controlX} ${controlY1} ${controlX} ${controlY2} ${end.x} ${end.y}`);
+          const route=buildTraceRoute(start,end,isLeft?-1:1);
+          let pathData=buildChamferedPath(route, TRACE_CHAMFER);
+          if(!pathData){
+            pathData=`M${start.x} ${start.y} L${end.x} ${end.y}`;
+          }
+          node.linkPath.setAttribute('d', pathData);
+          if(node.linkShadow){ node.linkShadow.setAttribute('d', pathData); }
+          if(node.linkHighlight){ node.linkHighlight.setAttribute('d', pathData); }
+          if(node.linkGroup){
+            const status=(node.data && node.data.status) || 'backlog';
+            const priority=(node.data && node.data.priority) || 'normal';
+            node.linkGroup.dataset.status=status;
+            node.linkGroup.dataset.priority=priority;
+          }
         }
         handleNodeResize(entries){
           if(!entries || !entries.length) return;
@@ -2852,7 +3088,7 @@ if ($view === 'map_edit') {
       }
       function commitInlineEditing(){ finishInlineEditing(true); }
       function currentEditingId(){ return inlineEditState ? inlineEditState.nodeId : null; }
-      jm.options.onInlineEdit=startInlineEditing;
+      jm.options.onInlineEdit=node=>openInspectorForNode(node,{focusTitle:true});
       jm.show(initialData);
       jmContainer.appendChild(overlay);
       syncOverlaySize();
@@ -2987,75 +3223,83 @@ if ($view === 'map_edit') {
       });
       window.addEventListener('pointerup',e=>finishPointerDrag(e,false));
       window.addEventListener('pointercancel',e=>finishPointerDrag(e,true));
-      window.addEventListener('resize',()=>requestAnimationFrame(updateHandlePosition));
-      document.addEventListener('scroll',()=>requestAnimationFrame(updateHandlePosition), true);
+      window.addEventListener('resize',()=>{
+        requestAnimationFrame(()=>{
+          updateHandlePosition();
+          if(inspectorVisible){ positionInspector(activeInspectorNode()); }
+        });
+      });
+      document.addEventListener('scroll',()=>{
+        requestAnimationFrame(()=>{
+          updateHandlePosition();
+          if(inspectorVisible){ positionInspector(activeInspectorNode()); }
+        });
+      }, true);
       requestAnimationFrame(updateHandlePosition);
       const titleInput=document.getElementById('map-title');
       const saveState=document.getElementById('save-state');
       const importInput=document.getElementById('import-input');
       const attachInput=document.getElementById('attach-file-input');
-      const attachFileBtn=document.getElementById('btn-attach-file');
-      const attachLinkBtn=document.getElementById('btn-attach-link');
       const inspector=document.getElementById('node-inspector');
+      const nodeTitleInput=document.getElementById('node-title');
       const nodeTypeSelect=document.getElementById('node-type');
       const nodeStatusSelect=document.getElementById('node-status');
       const nodePrioritySelect=document.getElementById('node-priority');
       const nodeOwnerInput=document.getElementById('node-owner');
       const nodeTagsInput=document.getElementById('node-tags');
       const nodeTagsPreview=document.getElementById('node-tags-preview');
-      const mobileToolbar=document.getElementById('mobile-toolbar');
-      const mobileSaveButton=mobileToolbar ? mobileToolbar.querySelector('button[data-action="save"]') : null;
-      const mobileSaveStatus=document.getElementById('mobile-save-status');
-      const sidebarToggle=document.getElementById('sidebar-toggle');
-      const sidebarBackdrop=document.getElementById('sidebar-backdrop');
-      const saveButton=document.getElementById('btn-save');
+      const popoverClose=inspector ? inspector.querySelector('.node-popover__close') : null;
+      const popoverApply=inspector ? inspector.querySelector('[data-popover="apply"]') : null;
+      const popoverCancel=inspector ? inspector.querySelector('[data-popover="cancel"]') : null;
+      const dock=document.getElementById('mind-dock');
+      const dockMoreToggle=document.getElementById('dock-more-toggle');
+      const dockMenu=document.getElementById('mind-dock-menu');
+      const dockButtons=dock ? Array.from(dock.querySelectorAll('.dock-btn')) : [];
+      const dockPrimaryButtons=dock ? dockButtons.filter(btn=>!btn.closest('.dock-menu')) : [];
+      const dockMenuButtons=dockMenu ? Array.from(dockMenu.querySelectorAll('button[data-action]')) : [];
+      const saveButton=dock ? dock.querySelector('.dock-btn[data-action="save"]') : null;
+      const addSiblingButton=dock ? dock.querySelector('.dock-btn[data-action="sibling"]') : null;
+      const addChildButton=dock ? dock.querySelector('.dock-btn[data-action="child"]') : null;
+      const attachFileBtn=dock ? dock.querySelector('.dock-btn[data-action="attach"]') : null;
+      const attachLinkBtn=dock ? dock.querySelector('.dock-btn[data-action="link"]') : null;
+      const deleteButton=dock ? dock.querySelector('.dock-btn[data-action="delete"]') : null;
       const fitButton=document.getElementById('btn-fit');
+      const centerButton=document.getElementById('btn-center');
+      const zoomInButton=document.getElementById('btn-zoom-in');
+      const zoomOutButton=document.getElementById('btn-zoom-out');
+      const collapseButton=document.getElementById('btn-collapse');
+      const collapseMenuButton=document.getElementById('btn-collapse-menu');
       const fitFloatingButton=document.getElementById('btn-fit-floating');
-      const addSiblingButton=document.getElementById('btn-add-sibling');
-      const addChildButton=document.getElementById('btn-add-child');
-      const deleteButton=document.getElementById('btn-delete');
-      let saveButtonDefault=saveButton ? saveButton.textContent : '保存';
-      if(saveButton){ saveButton.dataset.defaultLabel=saveButtonDefault; }
-      let mobileSaveDefault=mobileSaveButton ? mobileSaveButton.textContent : '保存';
-      if(mobileSaveButton){ mobileSaveButton.dataset.defaultLabel=mobileSaveDefault; }
+      const exportButton=document.getElementById('btn-export-json');
+      const importButton=document.getElementById('btn-import-json');
+      function readButtonLabel(button){
+        if(!button) return '';
+        const label=button.querySelector('.label');
+        return label ? label.textContent.trim() : (button.textContent || '').trim();
+      }
+      function setButtonLabel(button,text){
+        if(!button) return;
+        const label=button.querySelector('.label');
+        if(label){ label.textContent=text; }
+        else{ button.textContent=text; }
+      }
+      let saveButtonDefault=readButtonLabel(saveButton) || '保存';
       let dirty=false;
-      let mobileStatusTimer=null;
       const commandLog=[];
       window.__mindmapCommands=commandLog;
       const ATTACH_MAX_BYTES=15*1024*1024;
       const imageExts=['.png','.jpg','.jpeg','.gif','.webp','.bmp','.svg','.avif','.heic','.heif'];
       const textExts=['.txt','.md','.markdown','.csv','.json','.yaml','.yml','.log'];
       const videoExts=['.mp4','.mov','.mkv','.avi','.webm','.m4v'];
-      function setMobileSaveStatus(text, state, opts={}){
-        if(!mobileSaveStatus) return;
-        if(mobileStatusTimer){ clearTimeout(mobileStatusTimer); mobileStatusTimer=null; }
-        if(!text){
-          mobileSaveStatus.textContent='';
-          mobileSaveStatus.className='mobile-save-status';
-          return;
-        }
-        mobileSaveStatus.textContent=text;
-        mobileSaveStatus.className='mobile-save-status show';
-        if(state){ mobileSaveStatus.classList.add(`state-${state}`); }
-        if(opts.autoHide){
-          const duration=typeof opts.duration==='number' && isFinite(opts.duration)?opts.duration:1800;
-          mobileStatusTimer=setTimeout(()=>{
-            mobileStatusTimer=null;
-            if(!dirty){ setMobileSaveStatus('', null); }
-          }, duration);
-        }
-      }
       function setSaveButtonState(text, disabled){
         if(typeof text==='string'){
-          if(saveButton) saveButton.textContent=text;
-          if(mobileSaveButton) mobileSaveButton.textContent=text;
+          if(saveButton) setButtonLabel(saveButton, text);
         }else if(text===null){
-          if(saveButton) saveButton.textContent=saveButtonDefault;
-          if(mobileSaveButton) mobileSaveButton.textContent=mobileSaveDefault;
+          if(saveButton) setButtonLabel(saveButton, saveButtonDefault);
         }
-        if(typeof disabled==='boolean'){
-          if(saveButton) saveButton.disabled=disabled;
-          if(mobileSaveButton) mobileSaveButton.disabled=disabled;
+        if(typeof disabled==='boolean' && saveButton){
+          saveButton.disabled=disabled;
+          saveButton.classList.toggle('is-disabled', !!disabled);
         }
       }
       function markDirty(){
@@ -3064,8 +3308,7 @@ if ($view === 'map_edit') {
           saveState.textContent='未保存';
           saveState.classList.add('show','dirty');
         }
-        setSaveButtonState(null,false);
-        setMobileSaveStatus('未保存','dirty');
+        setSaveButtonState('未保存',false);
       }
       function showSaving(){
         if(saveState){
@@ -3074,7 +3317,6 @@ if ($view === 'map_edit') {
           saveState.classList.remove('dirty');
         }
         setSaveButtonState('⏳ 保存中...', true);
-        setMobileSaveStatus('保存中...','saving');
       }
       function markSaved(){
         dirty=false;
@@ -3084,24 +3326,99 @@ if ($view === 'map_edit') {
           saveState.classList.remove('dirty');
         }
         setSaveButtonState('✅ 保存成功', false);
-        setMobileSaveStatus('保存成功','success',{autoHide:true});
         setTimeout(()=>{
           if(!dirty){
             if(saveState) saveState.classList.remove('show');
             setSaveButtonState(null,false);
-            setMobileSaveStatus('', null);
           }
         },1500);
       }
-      const inspectorFields=[nodeTypeSelect,nodeStatusSelect,nodePrioritySelect,nodeOwnerInput,nodeTagsInput].filter(Boolean);
+      const inspectorFields=[nodeTitleInput,nodeTypeSelect,nodeStatusSelect,nodePrioritySelect,nodeOwnerInput,nodeTagsInput].filter(Boolean);
       let inspectorSyncing=false;
+      let inspectorVisible=false;
+      let inspectorNodeId=null;
+      function escapedNodeSelector(id){
+        if(!id) return null;
+        const safe=typeof CSS!=='undefined' && CSS && typeof CSS.escape==='function' ? CSS.escape(id) : id.replace(/"/g,'\\"');
+        return `.jsmind-node[nodeid="${safe}"]`;
+      }
+      function findNodeElement(node){
+        const id=typeof node==='string'?node:(node?node.id:null);
+        if(!id) return null;
+        const selector=escapedNodeSelector(id);
+        return selector ? document.querySelector(selector) : null;
+      }
+      function activeInspectorNode(){
+        if(inspectorNodeId){
+          const node=jm.get_node(inspectorNodeId);
+          if(node) return node;
+        }
+        return jm.get_selected_node();
+      }
+      function positionInspector(node){
+        if(!inspector || !inspectorVisible) return;
+        const pad=18;
+        const viewportWidth=window.innerWidth;
+        const viewportHeight=window.innerHeight;
+        const sheetMode=window.matchMedia('(max-width: 720px)').matches;
+        if(sheetMode){
+          const width=Math.min(viewportWidth - pad*2, 360);
+          inspector.style.width=`${Math.round(width)}px`;
+          inspector.style.left='50%';
+          inspector.style.top='auto';
+          inspector.style.bottom=`${Math.max(pad, 20)}px`;
+          inspector.style.transform='translateX(-50%)';
+          return;
+        }
+        inspector.style.width='';
+        inspector.style.transform='';
+        inspector.style.bottom='auto';
+        const target=node ? findNodeElement(node) : null;
+        inspector.style.left='0px';
+        inspector.style.top='0px';
+        const rect=inspector.getBoundingClientRect();
+        let left=(viewportWidth-rect.width)/2;
+        let top=(viewportHeight-rect.height)/2;
+        if(target){
+          const targetRect=target.getBoundingClientRect();
+          left=targetRect.right + pad;
+          top=targetRect.top - pad;
+        }
+        left=Math.min(viewportWidth-rect.width-pad, Math.max(pad, left));
+        top=Math.min(viewportHeight-rect.height-pad, Math.max(pad, top));
+        inspector.style.left=`${Math.round(left)}px`;
+        inspector.style.top=`${Math.round(top)}px`;
+      }
+      function openInspectorForNode(node,{focusTitle=false}={}){
+        if(!inspector || !node) return;
+        inspectorNodeId=node.id;
+        if(typeof jm.select_node==='function'){ jm.select_node(node.id); }
+        inspectorVisible=true;
+        setInspectorEnabled(true);
+        inspector.hidden=false;
+        inspector.style.visibility='hidden';
+        refreshInspector(node);
+        requestAnimationFrame(()=>{
+          positionInspector(node);
+          inspector.style.visibility='';
+          if(focusTitle && nodeTitleInput){
+            nodeTitleInput.focus();
+            nodeTitleInput.select();
+          }
+        });
+      }
+      function closeInspector(){
+        if(!inspector) return;
+        inspectorVisible=false;
+        inspectorNodeId=null;
+        inspector.hidden=true;
+      }
       function parseTagsString(value){
         if(!value) return [];
         return value.split(/[;,，\s]+/).map(tag=>tag.trim()).filter(Boolean).slice(0,12);
       }
       function setInspectorEnabled(enabled){
         inspectorFields.forEach(el=>{ el.disabled=!enabled; });
-        if(inspector){ inspector.classList.toggle('disabled', !enabled); }
       }
       function renderTagPreview(tags){
         if(!nodeTagsPreview) return;
@@ -3115,25 +3432,43 @@ if ($view === 'map_edit') {
         }
         tags.slice(0,12).forEach(tag=>{
           const span=document.createElement('span');
+          span.className='chip';
           span.textContent=tag;
           nodeTagsPreview.appendChild(span);
         });
+      }
+      function commitInspectorTitle(){
+        if(inspectorSyncing || !nodeTitleInput) return;
+        const node=activeInspectorNode();
+        if(!node) return;
+        const current=node.topic || '';
+        const next=(nodeTitleInput.value || '').trim();
+        if(!next || next===current) return;
+        commitInlineEditing();
+        jm.update_node(node.id, next);
+        markDirty();
+        requestAnimationFrame(()=>refreshInspector(jm.get_node(node.id)));
       }
       function refreshInspector(node){
         inspectorSyncing=true;
         if(!node){
           setInspectorEnabled(false);
+          inspectorNodeId=null;
+          if(nodeTitleInput) nodeTitleInput.value='';
           if(nodeTypeSelect) nodeTypeSelect.value='idea';
           if(nodeStatusSelect) nodeStatusSelect.value='backlog';
           if(nodePrioritySelect) nodePrioritySelect.value='normal';
           if(nodeOwnerInput) nodeOwnerInput.value='';
           if(nodeTagsInput) nodeTagsInput.value='';
           renderTagPreview([]);
+          if(inspectorVisible){ closeInspector(); }
           inspectorSyncing=false;
           return;
         }
         setInspectorEnabled(true);
+        inspectorNodeId=node.id;
         const data=normalizeNodeData(deepClone(node.data||{}));
+        if(nodeTitleInput) nodeTitleInput.value=node.topic || '';
         if(nodeTypeSelect) nodeTypeSelect.value=data.type||'idea';
         if(nodeStatusSelect) nodeStatusSelect.value=data.status||'backlog';
         if(nodePrioritySelect) nodePrioritySelect.value=data.priority||'normal';
@@ -3141,7 +3476,40 @@ if ($view === 'map_edit') {
         if(nodeTagsInput) nodeTagsInput.value=data.tags && data.tags.length?data.tags.join(', '):'';
         renderTagPreview(data.tags||[]);
         inspectorSyncing=false;
+        if(inspectorVisible){ positionInspector(node); }
       }
+      if(nodeTitleInput){
+        nodeTitleInput.addEventListener('keydown',e=>{
+          if(e.key==='Enter'){
+            e.preventDefault();
+            commitInspectorTitle();
+            closeInspector();
+          }
+        });
+        nodeTitleInput.addEventListener('blur',()=>{
+          if(inspectorVisible){ commitInspectorTitle(); }
+        });
+      }
+      if(popoverApply){
+        popoverApply.addEventListener('click',()=>{
+          commitInspectorTitle();
+          closeInspector();
+        });
+      }
+      if(popoverCancel){
+        popoverCancel.addEventListener('click',()=>{
+          const node=activeInspectorNode();
+          refreshInspector(node);
+          closeInspector();
+        });
+      }
+      if(popoverClose){ popoverClose.addEventListener('click',()=>closeInspector()); }
+      document.addEventListener('pointerdown',evt=>{
+        if(!inspectorVisible || !inspector) return;
+        if(inspector.contains(evt.target)){ return; }
+        if(nodeTitleInput && document.activeElement===nodeTitleInput){ commitInspectorTitle(); }
+        closeInspector();
+      }, true);
       refreshInspector(jm.get_selected_node());
       function applyInspectorChange(mutator){
         if(typeof mutator!=='function') return;
@@ -3163,7 +3531,11 @@ if ($view === 'map_edit') {
       }
       function deepClone(obj){ return obj ? JSON.parse(JSON.stringify(obj)) : null; }
       function ensureNode(){
-        let node=jm.get_selected_node();
+        let node=null;
+        if(inspectorVisible && inspectorNodeId){
+          node=jm.get_node(inspectorNodeId);
+        }
+        if(!node){ node=jm.get_selected_node(); }
         if(node) return node;
         if(typeof jm.get_root === 'function'){ node=jm.get_root(); }
         if(!node && initialData && initialData.data){ jm.select_node(initialData.data.id); node=jm.get_selected_node(); }
@@ -3459,37 +3831,104 @@ if ($view === 'map_edit') {
         nodeTagsInput.addEventListener('change',commitTags);
         nodeTagsInput.addEventListener('blur',commitTags);
       }
-      function setSidebar(open){
-        document.body.classList.toggle('sidebar-open', !!open);
-        if(sidebarToggle){ sidebarToggle.setAttribute('aria-expanded', open?'true':'false'); }
-        if(sidebarBackdrop){ sidebarBackdrop.hidden=!open; }
-      }
-      if(sidebarToggle){
-        sidebarToggle.addEventListener('click',()=>{
-          const willOpen=!document.body.classList.contains('sidebar-open');
-          setSidebar(willOpen);
+      const coarsePointer=window.matchMedia('(pointer: coarse)').matches;
+      const prefersReducedMotion=window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if(dock && !coarsePointer && !prefersReducedMotion){
+        dock.dataset.fisheye='on';
+        dock.addEventListener('mousemove',e=>{
+          const x=e.clientX;
+          dockPrimaryButtons.forEach(btn=>{
+            const rect=btn.getBoundingClientRect();
+            const center=rect.left + rect.width/2;
+            const dist=Math.abs(x-center);
+            const scale=Math.max(1, 1.18 - dist/720);
+            btn.style.setProperty('--dock-scale', scale.toFixed(3));
+          });
+        });
+        dock.addEventListener('mouseleave',()=>{
+          dockPrimaryButtons.forEach(btn=>btn.style.setProperty('--dock-scale','1'));
         });
       }
-      if(sidebarBackdrop){ sidebarBackdrop.addEventListener('click',()=>setSidebar(false)); }
-      const sidebarMedia=window.matchMedia('(max-width: 1024px)');
-      const handleSidebarMedia=(evt)=>{ if(!evt.matches){ setSidebar(false); } };
-      sidebarMedia.addEventListener('change',handleSidebarMedia);
-      setSidebar(false);
-      if(mobileToolbar){
-        mobileToolbar.addEventListener('click',e=>{
-          const btn=e.target.closest('button');
-          if(!btn) return;
-          switch(btn.dataset.action){
-            case 'save': saveMindmap(); break;
-            case 'add-sibling': addSiblingNode(); break;
-            case 'add-child': addChildNode(); break;
-            case 'attach-file': openAttachmentDialog(); break;
-            case 'attach-link': openLinkPrompt(); break;
-            case 'delete': deleteSelectedNode(); break;
+      function setDockMenu(expanded){
+        if(!dockMoreToggle || !dockMenu) return;
+        dockMoreToggle.setAttribute('aria-expanded', String(expanded));
+        const parent=dockMoreToggle.closest('.dock-more');
+        if(parent){ parent.setAttribute('aria-expanded', String(expanded)); }
+        dockMenu.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+      }
+      if(dockMoreToggle){
+        setDockMenu(false);
+        dockMoreToggle.addEventListener('click',()=>{
+          const expanded=dockMoreToggle.getAttribute('aria-expanded')==='true';
+          setDockMenu(!expanded);
+        });
+      }
+      document.addEventListener('pointerdown',evt=>{
+        if(!dockMenu || !dockMoreToggle) return;
+        if(dockMoreToggle.getAttribute('aria-expanded')!=='true') return;
+        if(dockMenu.contains(evt.target) || dockMoreToggle.contains(evt.target)) return;
+        setDockMenu(false);
+      });
+      function collapseCurrentNode(){
+        const node=ensureNode();
+        if(node){ jm.toggle_node(node.id); markDirty(); requestAnimationFrame(updateHandlePosition); }
+      }
+      function handleDockAction(action){
+        switch(action){
+          case 'save': saveMindmap(); break;
+          case 'sibling': addSiblingNode(); break;
+          case 'child': addChildNode(); break;
+          case 'attach': openAttachmentDialog(); break;
+          case 'link': openLinkPrompt(); break;
+          case 'delete': deleteSelectedNode(); break;
+          case 'import': if(importInput){ importInput.click(); } break;
+          case 'export': if(exportButton){ exportButton.click(); } break;
+          case 'toggle-fold':
+            if(collapseMenuButton){ collapseMenuButton.blur(); }
+            if(collapseButton){ collapseButton.click(); }
+            else{ collapseCurrentNode(); }
+            break;
+          case 'fit-view': if(fitButton){ fitButton.click(); } break;
+          case 'center': if(centerButton){ centerButton.click(); } break;
+          case 'zoom-in': if(zoomInButton){ zoomInButton.click(); } break;
+          case 'zoom-out': if(zoomOutButton){ zoomOutButton.click(); } break;
+          default: break;
+        }
+      }
+      if(dock){
+        dock.addEventListener('click',e=>{
+          const target=e.target.closest('[data-action]');
+          if(!target) return;
+          const action=target.dataset.action;
+          if(!action) return;
+          if(target.closest('.dock-more')){ setDockMenu(false); }
+          handleDockAction(action);
+        });
+        dock.addEventListener('keydown',e=>{
+          const current=e.target.closest('.dock-btn');
+          if(!current) return;
+          const index=dockPrimaryButtons.indexOf(current);
+          if(index<0) return;
+          if(e.key==='ArrowRight'){
+            e.preventDefault();
+            const next=dockPrimaryButtons[Math.min(index+1, dockPrimaryButtons.length-1)];
+            next?.focus();
+          }else if(e.key==='ArrowLeft'){
+            e.preventDefault();
+            const prev=dockPrimaryButtons[Math.max(index-1,0)];
+            prev?.focus();
           }
         });
       }
+      if(dockMenuButtons.length){
+        dockMenuButtons.forEach(btn=>btn.addEventListener('click',()=>setDockMenu(false)));
+      }
       document.addEventListener('keydown',e=>{
+        if(inspectorVisible && e.key==='Escape'){
+          e.preventDefault();
+          closeInspector();
+          return;
+        }
         const activeEl=document.activeElement;
         if(activeEl){
           const tag=activeEl.tagName || '';
@@ -3519,17 +3958,12 @@ if ($view === 'map_edit') {
       if(fitFloatingButton && fitButton){
         fitFloatingButton.onclick=()=>fitButton.click();
       }
-      const centerButton=document.getElementById('btn-center');
       if(centerButton){ centerButton.onclick=()=>{ if(!callView('move_to_center')) callView('center_root'); }; }
-      const zoomInButton=document.getElementById('btn-zoom-in');
       if(zoomInButton){ zoomInButton.onclick=()=>{ if(!callView('zoomIn')) callView('zoom_in'); }; }
-      const zoomOutButton=document.getElementById('btn-zoom-out');
       if(zoomOutButton){ zoomOutButton.onclick=()=>{ if(!callView('zoomOut')) callView('zoom_out'); }; }
-      const collapseButton=document.getElementById('btn-collapse');
       if(collapseButton){
         collapseButton.addEventListener('click',()=>{
-          const node=ensureNode();
-          if(node){ jm.toggle_node(node.id); markDirty(); requestAnimationFrame(updateHandlePosition); }
+          collapseCurrentNode();
         });
       }
       let dropHoverNode=null;
@@ -3592,7 +4026,6 @@ if ($view === 'map_edit') {
           if(type===jsMind.event_type.edit || type===jsMind.event_type.after_edit || type===jsMind.event_type.update){ markDirty(); }
         });
       }
-      const exportButton=document.getElementById('btn-export-json');
       if(exportButton){
         exportButton.addEventListener('click',()=>{
           const data=jm.get_data('node_tree');
@@ -3607,7 +4040,6 @@ if ($view === 'map_edit') {
           setTimeout(()=>URL.revokeObjectURL(url), 1000);
         });
       }
-      const importButton=document.getElementById('btn-import-json');
       if(importButton && importInput){
         importButton.addEventListener('click',()=>importInput.click());
       }
@@ -3659,7 +4091,6 @@ if ($view === 'map_edit') {
         }catch(err){
           alert(err.message||'保存失败');
           markDirty();
-          setMobileSaveStatus(err && err.message ? err.message : '保存失败','error');
         }
       }
       window.addEventListener('beforeunload',e=>{
@@ -3743,12 +4174,11 @@ if ($view === 'maps') {
       .header{display:flex;gap:16px;align-items:center;justify-content:space-between;flex-wrap:wrap;margin-bottom:24px}
       .header h1{margin:0;font:600 28px/1.2 'Cinzel','Noto Serif SC',serif;letter-spacing:.18em;text-transform:uppercase;color:var(--gold-400);text-shadow:0 0 26px rgba(227,198,139,.28)}
       .header .meta{color:var(--text-muted);font:14px/1.7 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em}
-      .btn{position:relative;padding:12px 18px;border-radius:16px;border:1px solid rgba(201,168,106,.38);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 0 0 0 rgba(227,198,139,0);overflow:hidden}
-      .btn::after{content:"";position:absolute;inset:2px;border-radius:12px;border:1px solid rgba(201,168,106,.22);opacity:.85;pointer-events:none;transition:opacity var(--transition)}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 24px rgba(227,198,139,.18);border-color:rgba(227,198,139,.6)}
-      .btn:hover::after{opacity:1}
-      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.26));color:var(--bg-void);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 22px 48px rgba(0,0,0,.6)}
-      .btn.danger{border-color:rgba(209,75,75,.55);color:#F6D6D6;box-shadow:0 0 24px rgba(209,75,75,.28)}
+      .btn{position:relative;padding:12px 18px;border-radius:16px;border:1px solid rgba(201,168,106,.38);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em;cursor:pointer;transition:transform var(--transition),border-color var(--transition);box-shadow:none;overflow:hidden}
+      .btn::after{content:none}
+      .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.6)}
+      .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.18),rgba(170,140,84,.26));color:var(--bg-void);box-shadow:none}
+      .btn.danger{border-color:rgba(209,75,75,.55);color:#F6D6D6;box-shadow:none}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px}
       .search{margin-top:20px;display:flex;gap:12px;align-items:center;padding:12px 16px;border-radius:18px;border:1px solid rgba(201,168,106,.34);background:linear-gradient(135deg,rgba(21,26,30,.82),rgba(15,19,22,.92));box-shadow:inset 0 0 22px rgba(0,0,0,.5);max-width:480px}
       .search input{all:unset;flex:1;color:var(--text-strong);font-size:15px;letter-spacing:.06em}
@@ -3923,13 +4353,13 @@ $all_total = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
   .brand .logo::after{content:"";position:absolute;inset:6px;border-radius:10px;border:1px solid rgba(201,168,106,.38);box-shadow:0 0 16px rgba(227,198,139,.3);animation:breathe 6s ease-in-out infinite}
   .brand h1{font:600 16px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);text-shadow:0 0 18px rgba(227,198,139,.25)}
   .controls{display:flex;gap:10px;flex-wrap:wrap;margin:10px 0 18px}
-  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:0 0 0 0 rgba(227,198,139,0);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);overflow:hidden}
-  .btn::after{content:"";position:absolute;inset:2px;border-radius:12px;border:1px solid rgba(201,168,106,.24);opacity:.85;transition:opacity var(--transition);pointer-events:none}
-  .btn:hover{transform:translateY(-2px);box-shadow:0 18px 34px rgba(0,0,0,.55),0 0 20px rgba(227,198,139,.18);border-color:rgba(227,198,139,.6)}
-  .btn:hover::after{opacity:1}
-  .btn:active{transform:translateY(0);box-shadow:0 0 12px rgba(227,198,139,.22)}
-  .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.22),rgba(170,140,84,.3));color:var(--bg-void);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 20px 40px rgba(0,0,0,.6)}
-  .btn.danger{color:var(--danger);border-color:rgba(255,93,125,.45);box-shadow:inset 0 0 16px rgba(255,93,125,.15)}
+  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:none;transition:transform var(--transition),border-color var(--transition);overflow:hidden}
+  .btn::after{content:none}
+  .btn:hover{transform:translateY(-2px);border-color:rgba(227,198,139,.6)}
+  .btn:hover::after{content:none}
+  .btn:active{transform:translateY(0)}
+  .btn.acc{background:linear-gradient(135deg,rgba(201,168,106,.22),rgba(170,140,84,.3));color:var(--bg-void);box-shadow:none}
+  .btn.danger{color:var(--danger);border-color:rgba(255,93,125,.45);box-shadow:none}
   .btn.small{padding:8px 12px;border-radius:12px;font-size:11px}
   .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 3px rgba(201,168,106,.25)}
   .section-title{font:600 12px/1 'Cinzel','Noto Serif SC',serif;text-transform:uppercase;letter-spacing:.24em;color:var(--gold-400);margin:14px 0 8px;text-shadow:0 0 14px rgba(227,198,139,.24)}
@@ -3939,7 +4369,7 @@ $all_total = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
   .cat:hover{transform:translateX(4px);border-color:rgba(201,168,106,.45);box-shadow:0 10px 22px rgba(0,0,0,.6)}
   .cat:hover::before{opacity:1}
   .cat.active{border-color:var(--glow);box-shadow:0 0 18px rgba(201,168,106,.3)}
-  .cat .name{font-weight:600;color:var(--text-strong);text-shadow:0 0 8px rgba(201,168,106,.18)}
+  .cat .name{flex:1;display:block;font-weight:600;color:var(--text-strong);text-shadow:0 0 8px rgba(201,168,106,.18)}
   .cat .count{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;color:var(--text-dim);letter-spacing:.14em;text-transform:uppercase}
   .footer{margin-top:18px;color:var(--text-dim);font-size:12px;line-height:1.8;text-shadow:0 0 10px rgba(201,168,106,.15)}
   .main{padding:24px 20px;background:linear-gradient(160deg,rgba(12,14,18,.82),rgba(10,12,14,.85));backdrop-filter:blur(14px) saturate(160%);position:relative}
@@ -4024,13 +4454,13 @@ $all_total = (int)$pdo->query('SELECT COUNT(*) FROM items')->fetchColumn();
     <div class="section-title">分类 · Categories</div>
     <div class="cat-list" id="cat-list">
       <a class="cat <?php echo ($cat==='all'?'active':''); ?>" href="?cat=all&q=<?php echo urlencode($q); ?>">
-        <div class="name">全部 · All</div><div class="count"><?php echo $all_total; ?></div>
+        <span class="name">全部 · All</span><span class="count"><?php echo $all_total; ?></span>
       </a>
       <?php foreach ($cats as $c): ?>
-      <div class="cat <?php echo ($cat===(string)$c['id']?'active':''); ?>" data-id="<?php echo $c['id']; ?>">
-        <a href="?cat=<?php echo $c['id']; ?>&q=<?php echo urlencode($q); ?>" style="flex:1" class="name"><?php echo h($c['name']); ?></a>
-        <div class="count"><?php echo (int)($counts[$c['id']] ?? 0); ?></div>
-      </div>
+      <a class="cat <?php echo ($cat===(string)$c['id']?'active':''); ?>" data-id="<?php echo $c['id']; ?>" href="?cat=<?php echo $c['id']; ?>&q=<?php echo urlencode($q); ?>">
+        <span class="name"><?php echo h($c['name']); ?></span>
+        <span class="count"><?php echo (int)($counts[$c['id']] ?? 0); ?></span>
+      </a>
       <?php endforeach; ?>
     </div>
     <div class="footer">
@@ -4220,14 +4650,15 @@ function refreshSidebarCats(cats, counts, total){
   const all=document.createElement('a');
   all.className='cat'+(urlCat==='all'?' active':'');
   all.href='?cat=all&q='+encodeURIComponent(qParam);
-  all.innerHTML='<div class="name">全部 · All</div><div class="count">'+(total??0)+'</div>';
+  all.innerHTML='<span class="name">全部 · All</span><span class="count">'+(total??0)+'</span>';
   list.appendChild(all);
   cats.forEach(c=>{
-    const div=document.createElement('div');
-    div.className='cat'+(String(urlCat)===String(c.id)?' active':'');
-    div.dataset.id=c.id;
-    div.innerHTML=`<a href="?cat=${c.id}&q=${encodeURIComponent(qParam)}" style="flex:1" class="name">${escapeHtml(c.name)}</a><div class="count">${counts[c.id]||0}</div>`;
-    list.appendChild(div);
+    const link=document.createElement('a');
+    link.className='cat'+(String(urlCat)===String(c.id)?' active':'');
+    link.dataset.id=c.id;
+    link.href='?cat='+c.id+'&q='+encodeURIComponent(qParam);
+    link.innerHTML=`<span class="name">${escapeHtml(c.name)}</span><span class="count">${counts[c.id]||0}</span>`;
+    list.appendChild(link);
   });
 }
 function fmt(ts){ const d=new Date(ts*1000); const p=n=>String(n).padStart(2,'0'); return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`; }

--- a/memo.php
+++ b/memo.php
@@ -1935,32 +1935,49 @@ if ($view === 'map_edit') {
       function alignToTraceGrid(value){
         return Math.round(value/TRACE_GRID)*TRACE_GRID;
       }
-      function buildTraceRoute(start,end,directionHint=1){
+      function buildTraceRoute(start,end,options=1){
         if(!start || !end){ return []; }
-        const points=[{x:start.x,y:start.y}];
-        const rawDx=end.x-start.x;
-        const absDx=Math.abs(rawDx);
-        const direction=(absDx<TRACE_GRID*0.5)
-          ? (directionHint>=0?1:-1)
-          : (rawDx>=0?1:-1);
-        const MIN_LEAD=TRACE_GRID*3;
-        let midX;
-        if(absDx<TRACE_GRID*0.25){
-          midX=start.x + direction*MIN_LEAD;
-        }else if(absDx<=TRACE_GRID*3){
-          const halfSpan=absDx/2;
-          midX=start.x + direction*Math.max(MIN_LEAD, halfSpan);
-        }else{
-          const maxLead=Math.max(MIN_LEAD, absDx - TRACE_GRID*2);
-          let lead=absDx*0.45;
-          lead=Math.min(Math.max(MIN_LEAD, lead), maxLead);
-          midX=start.x + direction*lead;
+        let axis='horizontal';
+        let directionHint=1;
+        if(typeof options==='number'){
+          directionHint=options>=0?1:-1;
+        }else if(options && typeof options==='object'){
+          if(options.axis==='vertical'){ axis='vertical'; }
+          if(typeof options.directionHint==='number'){
+            directionHint=options.directionHint>=0?1:-1;
+          }
         }
-        midX=alignToTraceGrid(midX);
-        const viaY=alignToTraceGrid(end.y);
-        points.push({x:midX,y:start.y});
-        if(!nearlyEqual(viaY,start.y)){
-          points.push({x:midX,y:viaY});
+        const leadKey=axis==='vertical'?'y':'x';
+        const crossKey=axis==='vertical'?'x':'y';
+        const points=[{x:start.x,y:start.y}];
+        const rawLead=end[leadKey]-start[leadKey];
+        const absLead=Math.abs(rawLead);
+        const direction=(absLead<TRACE_GRID*0.5)
+          ? directionHint
+          : (rawLead>=0?1:-1);
+        const MIN_LEAD=TRACE_GRID*3;
+        let midLead;
+        if(absLead<TRACE_GRID*0.25){
+          midLead=start[leadKey] + direction*MIN_LEAD;
+        }else if(absLead<=TRACE_GRID*3){
+          const halfSpan=absLead/2;
+          midLead=start[leadKey] + direction*Math.max(MIN_LEAD, halfSpan);
+        }else{
+          const maxLead=Math.max(MIN_LEAD, absLead - TRACE_GRID*2);
+          let lead=absLead*0.45;
+          lead=Math.min(Math.max(MIN_LEAD, lead), maxLead);
+          midLead=start[leadKey] + direction*lead;
+        }
+        midLead=alignToTraceGrid(midLead);
+        const viaCross=alignToTraceGrid(end[crossKey]);
+        const buildPoint=(lead,cross)=>axis==='vertical'
+          ? {x:cross, y:lead}
+          : {x:lead, y:cross};
+        const anchorCross=start[crossKey];
+        const midPoint=buildPoint(midLead, anchorCross);
+        points.push(midPoint);
+        if(!nearlyEqual(viaCross, anchorCross)){
+          points.push(buildPoint(midLead, viaCross));
         }
         points.push({x:end.x,y:end.y});
         const cleaned=[];
@@ -2751,10 +2768,33 @@ if ($view === 'map_edit') {
           if(!node.anchors) this.updateAnchors(node);
           if(!node.parent.anchors) this.updateAnchors(node.parent);
           const parent=node.parent;
-          const isLeft=node.dir===-1 || node.direction==='left' || node.absX<=parent.absX;
-          const start=isLeft ? parent.anchors.left : parent.anchors.right;
-          const end=isLeft ? node.anchors.right : node.anchors.left;
-          const route=buildTraceRoute(start,end,isLeft?-1:1);
+          const dx=(node.absX ?? 0) - (parent.absX ?? 0);
+          const dy=(node.absY ?? 0) - (parent.absY ?? 0);
+          const preferHorizontal=Math.abs(dx) >= Math.abs(dy);
+          let start=null;
+          let end=null;
+          let routeOptions;
+          if(preferHorizontal){
+            const toRight=dx>=0;
+            start=toRight ? parent.anchors.right : parent.anchors.left;
+            end=toRight ? node.anchors.left : node.anchors.right;
+            routeOptions={axis:'horizontal', directionHint: toRight ? 1 : -1};
+          }else{
+            const toBottom=dy>=0;
+            start=toBottom ? parent.anchors.bottom : parent.anchors.top;
+            end=toBottom ? node.anchors.top : node.anchors.bottom;
+            routeOptions={axis:'vertical', directionHint: toBottom ? 1 : -1};
+          }
+          if(!start || !end){
+            const fallbackStart=parent.anchors ? parent.anchors.center : {x:parent.absX,y:parent.absY};
+            const fallbackEnd=node.anchors ? node.anchors.center : {x:node.absX,y:node.absY};
+            const fallback=`M${fallbackStart.x} ${fallbackStart.y} L${fallbackEnd.x} ${fallbackEnd.y}`;
+            node.linkPath.setAttribute('d', fallback);
+            if(node.linkShadow){ node.linkShadow.setAttribute('d', fallback); }
+            if(node.linkHighlight){ node.linkHighlight.setAttribute('d', fallback); }
+            return;
+          }
+          const route=buildTraceRoute(start,end,routeOptions);
           let pathData=buildChamferedPath(route, TRACE_CHAMFER);
           if(!pathData){
             pathData=`M${start.x} ${start.y} L${end.x} ${end.y}`;


### PR DESCRIPTION
## Summary
- replace the mind map sidebar with a centered HUD and bottom dock that expose save/navigation commands while keeping the canvas full width
- add a floating node inspector popover with responsive styling in place of the sidebar form fields and update the touch-friendly dock interaction model
- update the editor script to drive the new dock actions, fish-eye scaling, and popover lifecycle while keeping keyboard shortcuts and attachment workflows intact

## Testing
- php -l memo.php

------
https://chatgpt.com/codex/tasks/task_e_68d9a86c085883289c1c439f9def8575