### PR TITLE
Support subdirectory deployments

### DIFF
--- a/core/Request.php
+++ b/core/Request.php
@@ -10,13 +10,15 @@ class Request
         private array $server,
         private array $files,
         private array $cookies,
-        private array &$session
+        private array &$session,
+        private string $basePath = ''
     ) {
+        $this->basePath = $this->normalizeBasePath($basePath ?: $this->detectBasePath($server));
     }
 
-    public static function fromGlobals(): self
+    public static function fromGlobals(string $basePath = ''): self
     {
-        return new self($_GET, $_POST, $_SERVER, $_FILES, $_COOKIE, $_SESSION);
+        return new self($_GET, $_POST, $_SERVER, $_FILES, $_COOKIE, $_SESSION, $basePath);
     }
 
     public function method(): string
@@ -71,5 +73,77 @@ class Request
     public function &sessionRef(): array
     {
         return $this->session;
+    }
+
+    public function basePath(): string
+    {
+        return $this->basePath;
+    }
+
+    public function path(): string
+    {
+        $uri = $this->server['REQUEST_URI'] ?? '/';
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $relative = $this->stripBasePath($path);
+
+        if ($relative === '' || $relative === null) {
+            return '/';
+        }
+
+        return '/' . ltrim($relative, '/');
+    }
+
+    private function normalizeBasePath(string $basePath): string
+    {
+        if ($basePath === '' || $basePath === '/') {
+            return '';
+        }
+
+        $basePath = trim($basePath);
+        if ($basePath === '') {
+            return '';
+        }
+
+        $parsed = parse_url($basePath, PHP_URL_PATH);
+        if (is_string($parsed)) {
+            $basePath = $parsed;
+        }
+
+        $basePath = '/' . trim($basePath, '/');
+
+        return $basePath === '/' ? '' : $basePath;
+    }
+
+    private function stripBasePath(string $path): string
+    {
+        if ($this->basePath === '') {
+            return $path;
+        }
+
+        if ($path === $this->basePath) {
+            return '/';
+        }
+
+        $prefixed = $this->basePath . '/';
+        if (str_starts_with($path, $prefixed)) {
+            return substr($path, strlen($this->basePath));
+        }
+
+        return $path;
+    }
+
+    private function detectBasePath(array $server): string
+    {
+        $scriptName = $server['SCRIPT_NAME'] ?? '';
+        if ($scriptName === '') {
+            return '';
+        }
+
+        $directory = str_replace('\\', '/', dirname($scriptName));
+        if ($directory === '/' || $directory === '.' || $directory === '') {
+            return '';
+        }
+
+        return $directory;
     }
 }

--- a/core/Router.php
+++ b/core/Router.php
@@ -24,8 +24,7 @@ class Router
     public function dispatch(Request $request): mixed
     {
         $method = $request->method();
-        $path = parse_url($request->server('REQUEST_URI', '/'), PHP_URL_PATH) ?: '/';
-        $normalized = $this->normalize($path);
+        $normalized = $this->normalize($request->path());
 
         if (!empty($this->routes[$method])) {
             foreach ($this->routes[$method] as $route => $handler) {

--- a/public/index.php
+++ b/public/index.php
@@ -9,9 +9,19 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
 }
 
-require __DIR__ . '/../bootstrap.php';
+/** @var \Core\Config $config */
+$config = require __DIR__ . '/../bootstrap.php';
 
-$request = Request::fromGlobals();
+$baseUrl = (string)($config->get('app.base_url', '') ?? '');
+$basePath = '';
+if ($baseUrl !== '') {
+    $parsedPath = parse_url($baseUrl, PHP_URL_PATH);
+    if (is_string($parsedPath)) {
+        $basePath = $parsedPath;
+    }
+}
+
+$request = Request::fromGlobals($basePath);
 $router = new Router();
 
 require __DIR__ . '/../routes/web.php';


### PR DESCRIPTION
## Summary
- allow Request instances to carry a normalized base path determined from configuration or server globals
- update router dispatching to match routes against the base-path-stripped request path
- bootstrap the application with configuration to compute the base path for subdirectory installs

## Testing
- php -l public/index.php
- php -l core/Request.php
- php -l core/Router.php

------
https://chatgpt.com/codex/tasks/task_e_68dbc8567c288328804b07549a58fc8f