### PR TITLE
Support subdirectory deployments

### DIFF
--- a/core/Router.php
+++ b/core/Router.php
@@ -5,6 +5,12 @@ namespace Core;
 class Router
 {
     private array $routes = [];
+    private string $basePath;
+
+    public function __construct(string $basePath = '')
+    {
+        $this->basePath = $this->prepareBasePath($basePath);
+    }
 
     public function get(string $path, callable $handler): void
     {
@@ -25,7 +31,7 @@ class Router
     {
         $method = $request->method();
         $path = parse_url($request->server('REQUEST_URI', '/'), PHP_URL_PATH) ?: '/';
-        $normalized = $this->normalize($path);
+        $normalized = $this->normalize($this->stripBasePath($path));
 
         if (!empty($this->routes[$method])) {
             foreach ($this->routes[$method] as $route => $handler) {
@@ -44,6 +50,49 @@ class Router
     private function normalize(string $path): string
     {
         return '/' . trim($path, '/');
+    }
+
+    private function prepareBasePath(string $basePath): string
+    {
+        $basePath = trim($basePath);
+        if ($basePath === '' || $basePath === '/') {
+            return '';
+        }
+
+        $parsed = parse_url($basePath, PHP_URL_PATH);
+        if (is_string($parsed) && $parsed !== '') {
+            $basePath = $parsed;
+        }
+
+        return '/' . trim($basePath, '/');
+    }
+
+    private function stripBasePath(string $path): string
+    {
+        if ($this->basePath === '') {
+            return $path;
+        }
+
+        $length = strlen($this->basePath);
+        if (strncmp($path, $this->basePath, $length) !== 0) {
+            return $path;
+        }
+
+        $next = substr($path, $length, 1);
+        if ($next !== '' && $next !== '/') {
+            return $path;
+        }
+
+        $stripped = substr($path, $length);
+        if ($stripped === '' || $stripped === false) {
+            return '/';
+        }
+
+        if ($stripped[0] !== '/') {
+            $stripped = '/' . ltrim($stripped, '/');
+        }
+
+        return $stripped;
     }
 
     private function match(string $route, string $path): ?array

--- a/public/index.php
+++ b/public/index.php
@@ -9,10 +9,30 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
 }
 
-require __DIR__ . '/../bootstrap.php';
+$config = require __DIR__ . '/../bootstrap.php';
+
+$baseUrl = (string)($config->get('app.base_url') ?? '');
+$basePath = '';
+
+if ($baseUrl !== '') {
+    $parsedPath = parse_url($baseUrl, PHP_URL_PATH);
+    if (is_string($parsedPath)) {
+        $basePath = $parsedPath;
+    }
+}
+
+if ($basePath === '') {
+    $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
+    if ($scriptName !== '') {
+        $scriptDir = str_replace('\\', '/', dirname($scriptName));
+        if ($scriptDir !== '/' && $scriptDir !== '\\' && $scriptDir !== '.') {
+            $basePath = $scriptDir;
+        }
+    }
+}
 
 $request = Request::fromGlobals();
-$router = new Router();
+$router = new Router($basePath);
 
 require __DIR__ . '/../routes/web.php';
 


### PR DESCRIPTION
## Summary
- allow the router to strip a configured base path before matching routes so subdirectory URLs resolve correctly
- detect the application base path from APP_URL or the script location when bootstrapping and pass it to the router

## Testing
- php -r "require 'bootstrap.php'; echo \"bootstrap ok\\n\";"
- php -l core/Router.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dbc8567c288328804b07549a58fc8f