### PR TITLE
Add cross-level link styling and inline node insertion controls

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -3797,11 +3797,15 @@ if ($view === 'map_edit') {
       .mind-links .trace.highlight{stroke:rgba(255,242,218,.32);stroke-width:0.8}
       .mind-relations{position:absolute;top:0;left:0;pointer-events:none;overflow:visible}
       .mind-relations .relation-group{pointer-events:none}
-      .mind-relations path{fill:none;stroke-linecap:round;stroke-linejoin:round}
-      .mind-relations .relation-shadow{stroke:rgba(75,195,209,.28);stroke-width:2.4;filter:url(#mindSoftGlow)}
-      .mind-relations .relation-core{stroke:rgba(75,195,209,.85);stroke-width:1.7;stroke-dasharray:8 10;filter:url(#mindSoftGlow)}
-      .mind-relations .relation-highlight{stroke:rgba(255,255,255,.4);stroke-width:0.9;opacity:.6}
+      .mind-relations path{fill:none;stroke-linecap:round;stroke-linejoin:bevel}
+      .mind-relations .relation-shadow{stroke:rgba(122,94,54,.5);stroke-width:2.3;filter:url(#mindSoftGlow)}
+      .mind-relations .relation-core{stroke:url(#mindGoldTrace);stroke-width:1.7;filter:url(#mindSoftGlow)}
+      .mind-relations .relation-highlight{stroke:rgba(255,242,218,.32);stroke-width:0.85;opacity:.85}
       .mind-relations .relation-core[data-bidirectional="true"]{stroke-dasharray:0}
+      .mind-link-inserts{position:absolute;inset:0;pointer-events:none;z-index:6}
+      .mind-link-inserts .link-insert-btn{position:absolute;transform:translate(-50%,-50%);width:32px;height:32px;border-radius:50%;border:1px solid rgba(227,198,139,.62);background:rgba(227,198,139,.18);color:var(--gold-400);font:600 18px/1 'Cinzel','Noto Serif SC',serif;display:flex;align-items:center;justify-content:center;box-shadow:0 8px 20px rgba(0,0,0,.35),0 0 18px rgba(227,198,139,.24);pointer-events:auto;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),background var(--transition),border-color var(--transition),opacity var(--transition);backdrop-filter:blur(6px)}
+      .mind-link-inserts .link-insert-btn:hover{transform:translate(-50%,-50%) scale(1.05);background:rgba(227,198,139,.26);border-color:rgba(227,198,139,.8);box-shadow:0 14px 28px rgba(0,0,0,.42),0 0 24px rgba(227,198,139,.32)}
+      .mind-link-inserts .link-insert-btn:focus-visible{outline:3px solid rgba(227,198,139,.45);outline-offset:2px}
       .mind-nodes{position:absolute;top:0;left:0}
       .jsmind-node{position:absolute;display:flex;flex-direction:column;align-items:flex-start;gap:10px;padding:18px 20px;border-radius:var(--r-md);color:var(--text-strong);font:600 14px/1.5 'Inter','Noto Sans SC',sans-serif;min-width:170px;max-width:320px;background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));border:1.6px solid rgba(201,168,106,.32);box-shadow:0 20px 48px rgba(0,0,0,.58),0 0 30px rgba(227,198,139,.12);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),filter var(--transition);backdrop-filter:blur(12px);letter-spacing:.04em}
       .jsmind-node::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-md) - 4px);border:1px solid rgba(201,168,106,.28);opacity:.85;pointer-events:none;box-shadow:0 0 24px rgba(227,198,139,.18)}
@@ -3927,7 +3931,7 @@ if ($view === 'map_edit') {
           </feMerge>
         </filter>
         <marker id="mindRelationArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
-          <path d="M0 0 L12 6 L0 12 Z" fill="rgba(75,195,209,.9)" />
+          <path d="M0 0 L12 6 L0 12 Z" fill="#E3C68B" />
         </marker>
       </defs>
     </svg>
@@ -4660,6 +4664,36 @@ if ($view === 'map_edit') {
         }
         return d;
       }
+      function computePolylineMidpoint(points){
+        if(!Array.isArray(points) || points.length<2) return null;
+        let total=0;
+        for(let i=1;i<points.length;i++){
+          const prev=points[i-1];
+          const curr=points[i];
+          total+=Math.hypot(curr.x-prev.x,curr.y-prev.y);
+        }
+        if(total<=0){
+          const first=points[0];
+          return {x:first.x,y:first.y};
+        }
+        const half=total/2;
+        let acc=0;
+        for(let i=1;i<points.length;i++){
+          const prev=points[i-1];
+          const curr=points[i];
+          const segment=Math.hypot(curr.x-prev.x,curr.y-prev.y);
+          if(acc+segment>=half){
+            const ratio=(half-acc)/segment;
+            return {
+              x:prev.x + (curr.x-prev.x)*ratio,
+              y:prev.y + (curr.y-prev.y)*ratio
+            };
+          }
+          acc+=segment;
+        }
+        const last=points[points.length-1];
+        return {x:last.x,y:last.y};
+      }
       function normalizeNodeData(value){
         if(!value || typeof value!=='object' || Array.isArray(value)) return {};
         const data=value;
@@ -4737,6 +4771,9 @@ if ($view === 'map_edit') {
           this.nodeLayer=document.createElement('div');
           this.nodeLayer.className='mind-nodes';
           this.viewport.appendChild(this.nodeLayer);
+          this.insertLayer=document.createElement('div');
+          this.insertLayer.className='mind-link-inserts';
+          this.viewport.appendChild(this.insertLayer);
           this.container.appendChild(this.viewport);
           this.sizeCache=new Map();
           this.measureHost=document.querySelector('.mind-measure') || document.createElement('div');
@@ -5024,6 +5061,78 @@ if ($view === 'map_edit') {
           this.select_node(newId);
           this.emit(SimpleMind.event_type.update);
           return node;
+        }
+        insert_node_between(parentNode, childNode, options={}){
+          const parent=typeof parentNode==='string'?this.get_node(parentNode):parentNode;
+          const child=typeof childNode==='string'?this.get_node(childNode):childNode;
+          if(!parent || !child || child.parent!==parent) return null;
+          const siblings=parent.children || [];
+          const index=siblings.indexOf(child);
+          if(index===-1) return null;
+          const modelChildren=this.ensureModelChildren(parent);
+          let childModel=null;
+          let modelIndex=modelChildren.findIndex(entry=>entry && entry.id===child.id);
+          if(modelIndex!==-1){ childModel=modelChildren[modelIndex]; }
+          if(!childModel && child && child.model){ childModel=child.model; }
+          if(modelIndex===-1){ modelIndex=index>=0?index:modelChildren.length; }
+          const rawTopic=options && typeof options.topic==='string'?options.topic.trim():'';
+          const topic=rawTopic || '新节点';
+          const newId=options && typeof options.id==='string' && options.id.trim()?options.id.trim():'node-'+Math.random().toString(36).slice(2,10);
+          const dataInput=options && options.data && typeof options.data==='object'?JSON.parse(JSON.stringify(options.data)):{};
+          const normalizedData=normalizeNodeData(dataInput);
+          const styleInput=options && options.style && typeof options.style==='object'?JSON.parse(JSON.stringify(options.style)):null;
+          const metaInput=options && options.meta && typeof options.meta==='object'?JSON.parse(JSON.stringify(options.meta)):null;
+          const expanded=options && options.expanded===false ? false : true;
+          const newModel={
+            id:newId,
+            topic,
+            data:normalizedData,
+            children:[],
+            direction:'right',
+            expanded
+          };
+          if(styleInput){ newModel.style=styleInput; }
+          if(metaInput){ newModel.meta=metaInput; }
+          if(childModel){ newModel.children=[childModel]; }
+          const newNode={
+            id:newId,
+            topic,
+            data:normalizedData,
+            parent:parent,
+            children:[child],
+            direction:'right',
+            expanded,
+            isroot:false,
+            style:styleInput||null,
+            meta:metaInput||null,
+            model:newModel,
+            depth:(parent.depth||0)+1
+          };
+          child.parent=newNode;
+          if(child.model){ child.model.direction='right'; }
+          siblings.splice(index,1,newNode);
+          modelChildren.splice(modelIndex,1,newModel);
+          if(!childModel && child.model){ newModel.children=[child.model]; }
+          this.nodes.set(newId,newNode);
+          this.updateSubtreeDepth(newNode, (parent.depth||0)+1);
+          this.computeLayout();
+          this.render();
+          this.select_node(newId);
+          this.emit(SimpleMind.event_type.update);
+          return this.nodes.get(newId) || newNode;
+        }
+        updateSubtreeDepth(node, depth){
+          if(!node) return;
+          node.depth=depth;
+          if(node.model){ node.model.direction=depth===0?'center':'right'; }
+          if(node.children && node.children.length){
+            const nextDepth=depth+1;
+            node.children.forEach(child=>{
+              if(!child) return;
+              child.parent=node;
+              this.updateSubtreeDepth(child, nextDepth);
+            });
+          }
         }
         remove_node(id){
           const node=this.nodes.get(id);
@@ -5588,9 +5697,16 @@ if ($view === 'map_edit') {
           this.nodeLayer.innerHTML='';
           while(this.linkLayer.firstChild){ this.linkLayer.removeChild(this.linkLayer.firstChild); }
           if(this.relationLayer){ while(this.relationLayer.firstChild){ this.relationLayer.removeChild(this.relationLayer.firstChild); } }
+          if(this.insertLayer){ this.insertLayer.innerHTML=''; }
           if(this.resizeObserver){ this.resizeObserver.disconnect(); }
           this.linkRegistry.clear();
           if(this.relationRegistry){ this.relationRegistry.clear(); }
+          this.nodes.forEach(node=>{
+            if(node){
+              node.linkInsertButton=null;
+              node.linkMidpoint=null;
+            }
+          });
           if(!this.root) return;
           const walk=(node)=>{
             node.el=this.buildNodeElement(node,{forMeasure:false});
@@ -5625,6 +5741,28 @@ if ($view === 'map_edit') {
               node.linkPath=core;
               node.linkHighlight=highlight;
               this.linkRegistry.set(node.id,{group,shadow,core,highlight});
+              if(this.insertLayer){
+                const insertBtn=document.createElement('button');
+                insertBtn.type='button';
+                insertBtn.className='link-insert-btn';
+                insertBtn.textContent='+';
+                insertBtn.title='在此处插入节点';
+                insertBtn.setAttribute('aria-label','在此处插入节点');
+                insertBtn.dataset.parentId=node.parent.id;
+                insertBtn.dataset.childId=node.id;
+                insertBtn.addEventListener('click',evt=>{
+                  evt.preventDefault();
+                  evt.stopPropagation();
+                  const payload={ parent:node.parent, child:node, button:insertBtn, midpoint:node.linkMidpoint ? {...node.linkMidpoint} : null };
+                  if(typeof this.options.onInsertBetween==='function'){
+                    this.options.onInsertBetween(payload, this);
+                  }else{
+                    this.insert_node_between(node.parent.id, node.id, { topic:'新节点' });
+                  }
+                });
+                this.insertLayer.appendChild(insertBtn);
+                node.linkInsertButton=insertBtn;
+              }
               this.updateLinkPath(node);
             }
             if(this.resizeObserver){ this.resizeObserver.observe(node.el); }
@@ -5655,6 +5793,7 @@ if ($view === 'map_edit') {
             shadow.classList.add('relation-shadow');
             const core=document.createElementNS('http://www.w3.org/2000/svg','path');
             core.classList.add('relation-core');
+            core.setAttribute('stroke','url(#mindGoldTrace)');
             core.dataset.bidirectional=relation.bidirectional?'true':'false';
             core.setAttribute('marker-end','url(#mindRelationArrow)');
             if(relation.bidirectional){ core.setAttribute('marker-start','url(#mindRelationArrow)'); }
@@ -5689,13 +5828,19 @@ if ($view === 'map_edit') {
           };
         }
         updateLinkPath(node){
-          if(!node || !node.parent || !node.linkPath) return;
+          if(!node || !node.parent || !node.linkPath){
+            if(node){
+              node.linkMidpoint=null;
+              this.positionInsertButton(node);
+            }
+            return;
+          }
           if(!node.anchors) this.updateAnchors(node);
           if(!node.parent.anchors) this.updateAnchors(node.parent);
           const parent=node.parent;
           const isLeft=node.dir===-1 || node.direction==='left' || node.absX<=parent.absX;
           const baseStart=isLeft ? parent.anchors.left : parent.anchors.right;
-          const end=isLeft ? node.anchors.right : node.anchors.left;
+          const endAnchor=isLeft ? node.anchors.right : node.anchors.left;
           const siblings=(parent.children||[]).filter(Boolean);
           const scale=(typeof this.scale==='number' && this.scale>0)?this.scale:1;
           let portYOffset=0;
@@ -5707,14 +5852,66 @@ if ($view === 'map_edit') {
             }
           }
           const start={x:baseStart.x,y:baseStart.y+portYOffset};
-          const route=buildTraceRoute(start,end,isLeft?-1:1);
+          const end={x:endAnchor.x,y:endAnchor.y};
+          let route=buildTraceRoute(start,end,isLeft?-1:1);
+          if(!Array.isArray(route) || route.length<2){
+            route=[start,end];
+          }
           let pathData=buildChamferedPath(route, TRACE_CHAMFER);
           if(!pathData){
             pathData=`M${start.x} ${start.y} L${end.x} ${end.y}`;
           }
+          const midpoint=computePolylineMidpoint(route) || {x:(start.x+end.x)/2,y:(start.y+end.y)/2};
+          node.linkMidpoint=midpoint;
+          this.positionInsertButton(node);
           node.linkPath.setAttribute('d', pathData);
           if(node.linkShadow){ node.linkShadow.setAttribute('d', pathData); }
           if(node.linkHighlight){ node.linkHighlight.setAttribute('d', pathData); }
+        }
+        positionInsertButton(node){
+          if(!node) return;
+          const btn=node.linkInsertButton;
+          if(!btn) return;
+          const point=node.linkMidpoint;
+          if(!point || !isFinite(point.x) || !isFinite(point.y)){
+            btn.style.display='none';
+            return;
+          }
+          btn.style.display='';
+          btn.style.left=`${point.x}px`;
+          btn.style.top=`${point.y}px`;
+        }
+        computeBoundaryPoint(node, direction, extend=0){
+          if(!node){ return null; }
+          let dx=direction && typeof direction.x==='number'?direction.x:0;
+          let dy=direction && typeof direction.y==='number'?direction.y:0;
+          if(Math.abs(dx)<0.0001 && Math.abs(dy)<0.0001){
+            dx=1;
+            dy=0;
+          }
+          const width=Math.max(30, node.width || (node.el?node.el.offsetWidth:0) || 0);
+          const height=Math.max(24, node.height || (node.el?node.el.offsetHeight:0) || 0);
+          const halfW=width/2;
+          const halfH=height/2;
+          const scaleX=dx===0?Infinity:halfW/Math.abs(dx);
+          const scaleY=dy===0?Infinity:halfH/Math.abs(dy);
+          let scale=Math.min(scaleX, scaleY);
+          if(!isFinite(scale) || scale<=0){ scale=0; }
+          const cx=node.absX;
+          const cy=node.absY;
+          let px=cx + dx*scale;
+          let py=cy + dy*scale;
+          const len=Math.hypot(dx,dy) || 1;
+          if(scale===0){
+            px=cx + dx/len*halfW;
+            py=cy + dy/len*halfH;
+          }
+          if(extend){
+            const clamp=Math.max(-len*0.45, Math.min(len*0.45, extend));
+            px+=dx/len*clamp;
+            py+=dy/len*clamp;
+          }
+          return {x:px,y:py};
         }
         updateRelationPath(relation){
           if(!relation) return;
@@ -5725,20 +5922,26 @@ if ($view === 'map_edit') {
           if(!fromNode || !toNode) return;
           if(!fromNode.anchors) this.updateAnchors(fromNode);
           if(!toNode.anchors) this.updateAnchors(toNode);
-          const start=fromNode.anchors ? fromNode.anchors.center : null;
-          const end=toNode.anchors ? toNode.anchors.center : null;
-          if(!start || !end) return;
-          const dx=end.x-start.x;
-          const dy=end.y-start.y;
+          const startCenter={x:fromNode.absX,y:fromNode.absY};
+          const endCenter={x:toNode.absX,y:toNode.absY};
+          const direction={x:endCenter.x-startCenter.x,y:endCenter.y-startCenter.y};
+          const rawDistance=Math.hypot(direction.x,direction.y) || 1;
+          const arrowClearance=Math.min(28, Math.max(12, rawDistance*0.08));
+          const tailClearance=relation && relation.bidirectional ? arrowClearance : Math.min(14, arrowClearance*0.6);
+          const startPoint=this.computeBoundaryPoint(fromNode, direction, tailClearance);
+          const endPoint=this.computeBoundaryPoint(toNode, {x:startCenter.x-endCenter.x,y:startCenter.y-endCenter.y}, -arrowClearance);
+          if(!startPoint || !endPoint) return;
+          const dx=endPoint.x-startPoint.x;
+          const dy=endPoint.y-startPoint.y;
           const distance=Math.hypot(dx,dy) || 1;
           const normalX=distance?-dy/distance:0;
           const normalY=distance?dx/distance:0;
           const offset=Math.min(140, Math.max(30, distance*0.2));
-          const ctrl1x=start.x + dx*0.25 + normalX*offset;
-          const ctrl1y=start.y + dy*0.25 + normalY*offset;
-          const ctrl2x=start.x + dx*0.75 - normalX*offset;
-          const ctrl2y=start.y + dy*0.75 - normalY*offset;
-          const pathData=`M${start.x} ${start.y} C ${ctrl1x} ${ctrl1y}, ${ctrl2x} ${ctrl2y}, ${end.x} ${end.y}`;
+          const ctrl1x=startPoint.x + dx*0.25 + normalX*offset;
+          const ctrl1y=startPoint.y + dy*0.25 + normalY*offset;
+          const ctrl2x=startPoint.x + dx*0.75 - normalX*offset;
+          const ctrl2y=startPoint.y + dy*0.75 - normalY*offset;
+          const pathData=`M${startPoint.x} ${startPoint.y} C ${ctrl1x} ${ctrl1y}, ${ctrl2x} ${ctrl2y}, ${endPoint.x} ${endPoint.y}`;
           entry.shadow.setAttribute('d', pathData);
           entry.core.setAttribute('d', pathData);
           entry.highlight.setAttribute('d', pathData);
@@ -6019,10 +6222,37 @@ if ($view === 'map_edit') {
     const jm=new jsMind({
       container:'jsmind-container',
       editable:true,
-        theme:'fresh-blue',
-        support_html:true,
-        mode:'full',
+      onInsertBetween:(context)=>handleInsertBetweenRequest(context),
+      theme:'fresh-blue',
+      support_html:true,
+      mode:'full',
+    });
+    function handleInsertBetweenRequest(context){
+      if(!jm || typeof jm.insert_node_between!=='function') return;
+      const parent=context && context.parent ? context.parent : null;
+      const child=context && context.child ? context.child : null;
+      if(!parent || !child) return;
+      if(context && context.button && typeof context.button.blur==='function'){
+        context.button.blur();
+      }
+      commitInlineEditing();
+      const parentName=(parent.topic || parent.id || '').trim() || parent.id;
+      const childName=(child.topic || child.id || '').trim() || child.id;
+      const defaultTopic='新节点';
+      const promptText=`将在「${parentName}」与「${childName}」之间插入新节点，请输入标题：`;
+      const input=prompt(promptText, defaultTopic);
+      if(input===null) return;
+      const topic=(input||'').trim() || defaultTopic;
+      const created=jm.insert_node_between(parent.id, child.id, { topic });
+      if(!created) return;
+      markDirty();
+      scheduleHandleRefresh();
+      refreshInspector(jm.get_selected_node());
+      requestAnimationFrame(()=>{
+        const target=jm.get_node(created.id);
+        if(target){ startInlineEditing(target); }
       });
+    }
       const blobUrlRegistry=new Set();
       const externalScriptCache=new Map();
       function loadExternalScript(src, resolver){


### PR DESCRIPTION
## Summary
- unify relation lines with gold styling and introduce overlay controls for inserting nodes directly on connectors
- extend the mind map engine to track link midpoints, expose insert callbacks, and keep relation arrows clear of node bodies
- add node insertion logic and prompt-based UI flow so users can drop a new node between any existing parent/child pair

## Testing
- php -l memo.php
- php memo.php > /tmp/memo_output.html

------
https://chatgpt.com/codex/tasks/task_e_68e4484d733c83288627235368f17839