### PR TITLE
Refine dock layout and add export transition

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -3835,15 +3835,9 @@ if ($view === 'map_edit') {
       .node-collapse-marker:focus-visible{outline:3px solid rgba(75,195,209,.35);outline-offset:2px}
       .node-collapse-marker .icon{font-size:14px;line-height:1}
       .jsmind-node.is-collapsed .node-collapse-marker{background:rgba(201,168,106,.2);border-color:rgba(201,168,106,.46)}
-      .mind-dock-wrap{position:fixed;left:50%;bottom:calc(var(--safe-bottom) + 26px);transform:translateX(-50%);pointer-events:none;z-index:120;width:min(calc(100vw - 40px - var(--safe-left) - var(--safe-right)),720px)}
-      .mind-dock-wrap::before,.mind-dock-wrap::after{content:"";position:absolute;top:50%;transform:translateY(-50%);width:26px;height:70%;pointer-events:none;opacity:0;transition:opacity var(--t-fast) var(--ease);z-index:0}
-      .mind-dock-wrap::before{left:8px;background:linear-gradient(90deg,rgba(10,12,14,.8),rgba(10,12,14,0))}
-      .mind-dock-wrap::after{right:8px;background:linear-gradient(270deg,rgba(10,12,14,.8),rgba(10,12,14,0))}
-      .mind-dock-wrap[data-scroll-left="true"]::before{opacity:.8}
-      .mind-dock-wrap[data-scroll-right="true"]::after{opacity:.8}
-      .mind-dock{pointer-events:auto;display:flex;align-items:center;gap:12px;padding:12px 16px;border-radius:28px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.85));border:1px solid rgba(201,168,106,.32);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 32px rgba(227,198,139,.12) inset;backdrop-filter:blur(12px);position:relative;justify-content:flex-start;overflow-x:auto;scrollbar-width:none;-webkit-overflow-scrolling:touch;overscroll-behavior-x:contain;touch-action:pan-x;scroll-snap-type:x proximity}
-      .mind-dock::-webkit-scrollbar{display:none}
-      .dock-btn{position:relative;display:grid;grid-template-rows:auto auto;align-items:center;justify-items:center;width:92px;height:66px;border-radius:18px;padding:8px 6px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:0 0 auto;scroll-snap-align:center}
+      .mind-dock-wrap{position:fixed;left:50%;bottom:calc(var(--safe-bottom) + 20px);transform:translateX(-50%);pointer-events:none;z-index:120;width:min(calc(100vw - 40px - var(--safe-left) - var(--safe-right)),860px)}
+      .mind-dock{pointer-events:auto;display:flex;align-items:center;justify-content:center;flex-wrap:wrap;gap:16px;padding:14px 22px;border-radius:26px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.85));border:1px solid rgba(201,168,106,.32);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 32px rgba(227,198,139,.12) inset;backdrop-filter:blur(12px);position:relative;overflow:visible}
+      .dock-btn{position:relative;display:grid;grid-template-rows:auto auto;align-items:center;justify-items:center;min-width:94px;height:60px;border-radius:18px;padding:10px 8px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 110px}
       .dock-btn .icon{font-size:20px}
       .dock-btn .label{font-size:12px}
       @media (hover:hover) and (pointer:fine){
@@ -3863,10 +3857,16 @@ if ($view === 'map_edit') {
       .dock-btn[data-state="saved"]{color:var(--gold-400)}
       .dock-sep{width:12px;height:44px;border-right:1px solid rgba(201,168,106,.24);opacity:.6}
       .mind-shell[data-fisheye="on"] .dock-btn{transform-origin:50% 65%}
-      @media (max-width:960px){.mind-dock-wrap{width:min(calc(100vw - 32px),660px)}.mind-dock{gap:10px;padding:10px 14px}.dock-btn{width:84px;height:60px}}
-      @media (max-width:720px){.mind-dock-wrap{width:calc(100vw - 24px)}.mind-dock{padding:10px 14px;border-radius:24px;gap:10px}.dock-btn{width:78px;height:56px}.dock-btn .label{font-size:11px}}
-      @media (max-width:600px){.dock-btn{width:72px;height:54px}.dock-btn .icon{font-size:18px}.dock-sep{display:none}}
-      @media (prefers-reduced-motion: reduce){.dock-btn,.dock-btn:hover{transition:none!important;transform:none!important}.mind-shell[data-fisheye="on"] .dock-btn{transform:none!important}}
+      .export-transition{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;padding:40px;z-index:200;background:rgba(8,10,12,.86);backdrop-filter:blur(18px);opacity:0;pointer-events:none;transition:opacity var(--t-fast) var(--ease)}
+      .export-transition::before{content:"";position:absolute;inset:24px;border-radius:28px;border:1px solid rgba(201,168,106,.28);box-shadow:0 0 60px rgba(201,168,106,.18) inset;opacity:.6}
+      .export-transition__glow{position:absolute;width:360px;height:360px;border-radius:50%;background:radial-gradient(circle at center,rgba(227,198,139,.35),rgba(170,140,84,.05) 70%,transparent);filter:blur(18px);opacity:.75;animation:exportPulse 2.8s ease-in-out infinite}
+      .export-transition__label{position:relative;font:600 15px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase;color:var(--gold-300,#E3C68B);text-align:center;text-shadow:0 4px 22px rgba(0,0,0,.45)}
+      .export-transition[data-active="true"]{opacity:1;pointer-events:auto}
+      @keyframes exportPulse{0%{transform:scale(0.92);opacity:.5}50%{transform:scale(1.08);opacity:.9}100%{transform:scale(0.92);opacity:.5}}
+      @media (max-width:1024px){.mind-dock-wrap{width:min(calc(100vw - 32px - var(--safe-left) - var(--safe-right)),820px)}.mind-dock{gap:14px;padding:12px 18px}}
+      @media (max-width:720px){.mind-dock-wrap{width:calc(100vw - 24px)}.mind-dock{padding:12px 16px;border-radius:24px;gap:12px}.dock-btn{min-width:0;flex:1 1 calc(33.333% - 12px);height:56px}.dock-btn .label{font-size:11px}}
+      @media (max-width:520px){.dock-btn{flex:1 1 calc(50% - 12px);height:54px}.dock-btn .icon{font-size:18px}.dock-sep{display:none}}
+      @media (prefers-reduced-motion: reduce){.dock-btn,.dock-btn:hover{transition:none!important;transform:none!important}.mind-shell[data-fisheye="on"] .dock-btn{transform:none!important}.export-transition__glow{animation:none!important}}
       .mind-relation-toast{position:absolute;left:50%;top:24px;transform:translateX(-50%) translateY(-8px);padding:10px 16px;border-radius:18px;border:1px solid rgba(75,195,209,.4);background:rgba(10,16,20,.88);color:rgba(191,242,255,.92);font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;box-shadow:0 18px 40px rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity var(--transition),transform var(--transition);z-index:110}
       .mind-relation-toast[data-visible="true"]{opacity:1;transform:translateX(-50%) translateY(0)}
       .mind-shell[data-relation-mode="pending"] .mind-stage::after{content:"";position:absolute;inset:0;border:1px dashed rgba(75,195,209,.35);border-radius:inherit;pointer-events:none;animation:relationPulse 1.2s infinite ease-in-out}
@@ -4096,6 +4096,10 @@ if ($view === 'map_edit') {
           <button type="button" data-settings-close>关闭</button>
         </div>
       </div>
+    </div>
+    <div class="export-transition" id="export-transition" aria-hidden="true" role="status" aria-live="polite">
+      <div class="export-transition__glow" aria-hidden="true"></div>
+      <div class="export-transition__label">正在导出，请稍候…</div>
     </div>
     <script>
       (function(){
@@ -6862,7 +6866,6 @@ if ($view === 'map_edit') {
       const mindInfoHandleIcon=mindInfoHandle ? mindInfoHandle.querySelector('.icon') : null;
       const mindInfoContent=mindInfoBar ? mindInfoBar.querySelector('.mind-info-content') : null;
       const dock=document.getElementById('mind-dock');
-      const dockWrap=document.querySelector('.mind-dock-wrap');
       const dockButtons=dock ? Array.from(dock.querySelectorAll('.dock-btn[data-action]')) : [];
       const dockSaveButton=dock ? dock.querySelector('.dock-btn[data-action="save"]') : null;
       const dockSaveLabel=dockSaveButton ? dockSaveButton.querySelector('.label') : null;
@@ -6892,8 +6895,33 @@ if ($view === 'map_edit') {
       const fisheyeToggle=document.getElementById('setting-fisheye');
       const pointerMedia=window.matchMedia ? window.matchMedia('(pointer: coarse)') : null;
       let pointerIsCoarse=pointerMedia ? pointerMedia.matches : false;
+      const exportTransition=document.getElementById('export-transition');
+      const exportTransitionLabel=exportTransition ? exportTransition.querySelector('.export-transition__label') : null;
+      let exportTransitionTimer=null;
       if(mapDeleteButton){ mapDeleteButton.disabled=!currentMapId; }
       if(pointerIsCoarse && fisheyeToggle){ fisheyeToggle.checked=false; }
+      const waitForNextFrame=()=>new Promise(resolve=>requestAnimationFrame(()=>resolve()));
+      const waitFor=(ms=0)=>new Promise(resolve=>setTimeout(resolve,ms));
+      function showExportTransition(format){
+        if(!exportTransition) return;
+        if(exportTransitionTimer){ clearTimeout(exportTransitionTimer); exportTransitionTimer=null; }
+        if(exportTransitionLabel){
+          let label='正在导出，请稍候…';
+          if(format==='pdf'){ label='正在导出 PDF，请稍候…'; }
+          else if(format==='jpg'){ label='正在导出 JPG，请稍候…'; }
+          exportTransitionLabel.textContent=label;
+        }
+        exportTransition.dataset.active='true';
+        exportTransition.setAttribute('aria-hidden','false');
+      }
+      function hideExportTransition(){
+        if(!exportTransition) return;
+        exportTransition.dataset.active='false';
+        exportTransitionTimer=setTimeout(()=>{
+          if(exportTransition){ exportTransition.setAttribute('aria-hidden','true'); }
+          exportTransitionTimer=null;
+        },260);
+      }
       let infoBarCollapsed=false;
       function applyInfoBarState(){
         if(!mindInfoBar) return;
@@ -6934,17 +6962,6 @@ if ($view === 'map_edit') {
       }
       if(mindInfoBar){
         mindInfoBar.addEventListener('focusin',()=>{ expandInfoBar(); });
-      }
-      function updateDockScrollMarkers(){
-        if(!dock || !dockWrap) return;
-        const maxScroll=Math.max(0, dock.scrollWidth - dock.clientWidth);
-        if(maxScroll <= 1){
-          dockWrap.dataset.scrollLeft='false';
-          dockWrap.dataset.scrollRight='false';
-          return;
-        }
-        dockWrap.dataset.scrollLeft=dock.scrollLeft > 4 ? 'true' : 'false';
-        dockWrap.dataset.scrollRight=dock.scrollLeft < maxScroll - 4 ? 'true' : 'false';
       }
       function isFisheyeEnabled(){
         return !pointerIsCoarse && (!fisheyeToggle || fisheyeToggle.checked);
@@ -8420,16 +8437,6 @@ if ($view === 'map_edit') {
         });
       }
       if(dock){
-        updateDockScrollMarkers();
-        window.addEventListener('resize',updateDockScrollMarkers);
-        dock.addEventListener('scroll',updateDockScrollMarkers);
-        dock.addEventListener('wheel',e=>{
-          const dominant=Math.abs(e.deltaX) > Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
-          if(!dominant) return;
-          dock.scrollLeft += dominant;
-          updateDockScrollMarkers();
-          e.preventDefault();
-        });
         dock.addEventListener('click',e=>{
           const btn=e.target.closest('.dock-btn');
           if(!btn || !dock.contains(btn)) return;
@@ -8813,7 +8820,14 @@ if ($view === 'map_edit') {
         const overlayDisplay=overlay ? overlay.style.display : null;
         let exportHost=null;
         let layoutSnapshot=null;
+        let transitionActive=false;
         try{
+          if(format==='pdf' || format==='jpg'){
+            showExportTransition(format);
+            transitionActive=true;
+            await waitForNextFrame();
+            await waitFor(140);
+          }
           const htmlToImage=await ensureHtmlToImage();
           const computedStyle=getComputedStyle(document.body);
           const backgroundColor=(computedStyle.getPropertyValue('--bg-void') || computedStyle.backgroundColor || '#0A0C0E').trim() || '#0A0C0E';
@@ -8922,6 +8936,9 @@ if ($view === 'map_edit') {
           if(layoutSnapshot){ restoreLayoutSnapshot(jm, layoutSnapshot); }
           if(exportHost && exportHost.parentElement){ exportHost.remove(); }
           if(overlay){ overlay.style.display=overlayDisplay || ''; }
+          if(transitionActive){
+            hideExportTransition();
+          }
         }
       }
       function openImportModeDialog(fileName, data){


### PR DESCRIPTION
## Summary
- widen and reorganize the bottom dock into a fixed, wrapped layout that works consistently on desktop and mobile
- add a full-screen export transition overlay that plays during PDF and JPG exports to hide intermediate rendering artifacts

## Testing
- php -l memo.php
- php memo.php > /tmp/memo.html

------
https://chatgpt.com/codex/tasks/task_e_68e50ac60bd0832895a2e48a06ba9f03