### PR TITLE
优化关联线和工具栏快捷键展示

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -3970,6 +3970,9 @@ if ($view === 'map_edit') {
       .mind-relations .relation-shadow{stroke:rgba(122,94,54,.55);stroke-width:2.1;opacity:.65;filter:url(#mindSoftGlow);transition:stroke var(--transition),opacity var(--transition)}
       .mind-relations .relation-core{stroke:url(#mindGoldTrace);stroke-width:1.6;filter:url(#mindSoftGlow);transition:stroke var(--transition),stroke-width var(--transition)}
       .mind-relations .relation-highlight{stroke:rgba(255,242,218,.32);stroke-width:0.8;transition:stroke var(--transition),stroke-width var(--transition),opacity var(--transition)}
+      .mind-relations .relation-direction{font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.4em;text-transform:uppercase;fill:rgba(227,198,139,.78);stroke:rgba(12,16,18,.7);stroke-width:.6;paint-order:stroke fill;filter:url(#mindSoftGlow);opacity:.9;pointer-events:none}
+      .mind-relations .relation-direction.reverse{opacity:.82}
+      .mind-relations .relation-direction textPath{dominant-baseline:middle}
       .mind-relations .relation-core{pointer-events:stroke;cursor:pointer}
       .mind-relations .relation-highlight{pointer-events:none}
       .mind-relations .relation-group[data-selected="true"]{filter:drop-shadow(0 0 6px rgba(191,242,255,.45)) drop-shadow(0 0 18px rgba(191,242,255,.3))}
@@ -4010,15 +4013,11 @@ if ($view === 'map_edit') {
       .mind-dock-wrap{position:fixed;left:50%;bottom:calc(var(--safe-bottom) + 18px);transform:translateX(-50%);pointer-events:none;z-index:120;max-width:min(calc(100vw - 32px - var(--safe-left) - var(--safe-right)),1120px);width:100%;display:flex;justify-content:center}
       .mind-dock{pointer-events:auto;display:flex;flex-wrap:nowrap;align-items:stretch;justify-content:center;gap:14px;padding:16px 24px;border-radius:32px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.85));border:1px solid rgba(201,168,106,.32);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 32px rgba(227,198,139,.12) inset;backdrop-filter:blur(12px);position:relative;width:100%;max-width:100%;box-sizing:border-box;touch-action:pan-x pan-y;flex:0 1 auto;margin:0 auto;overflow-x:auto;scrollbar-width:none;-webkit-overflow-scrolling:touch;overscroll-behavior-x:contain}
       .mind-dock::-webkit-scrollbar{display:none}
-      .dock-btn{position:relative;display:grid;grid-template-rows:auto auto;align-items:center;justify-items:center;height:66px;border-radius:18px;padding:8px 6px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 clamp(90px,9vw,132px);min-width:74px;max-width:148px}
+      .dock-btn{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;height:66px;border-radius:18px;padding:10px 8px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 clamp(90px,9vw,132px);min-width:74px;max-width:148px}
       .dock-btn .icon{font-size:20px}
+      .dock-btn .label-group{display:flex;flex-direction:column;align-items:center;gap:2px}
       .dock-btn .label{font-size:12px}
-      @media (hover:hover) and (pointer:fine){
-        .dock-btn[data-tip]::after{content:attr(data-tip);position:absolute;bottom:100%;left:50%;transform:translate(-50%,6px);padding:6px 10px;border-radius:12px;border:1px solid rgba(201,168,106,.38);background:rgba(12,16,18,.92);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;white-space:nowrap;opacity:0;pointer-events:none;transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease);box-shadow:0 12px 28px rgba(0,0,0,.45)}
-        .dock-btn[data-tip]::before{content:"";position:absolute;bottom:100%;left:50%;transform:translate(-50%,6px);border-width:6px;border-style:solid;border-color:rgba(12,16,18,.92) transparent transparent transparent;opacity:0;transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
-        .dock-btn[data-tip]:hover::after,.dock-btn[data-tip]:focus-visible::after{opacity:1;transform:translate(-50%,-4px)}
-        .dock-btn[data-tip]:hover::before,.dock-btn[data-tip]:focus-visible::before{opacity:1;transform:translate(-50%,-4px)}
-      }
+      .dock-btn .shortcut{font:600 10px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase;color:rgba(227,198,139,.72)}
       .dock-btn:hover{transform:translateY(-3px);border-color:var(--gold-500);background:rgba(201,168,106,.16);box-shadow:0 0 26px rgba(227,198,139,.18)}
       .dock-btn:active{transform:translateY(-1px)}
       .dock-btn:focus-visible{outline:3px solid rgba(75,195,209,.35);outline-offset:2px}
@@ -4186,9 +4185,6 @@ if ($view === 'map_edit') {
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>
-        <marker id="mindRelationArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
-          <path d="M0 0 L12 6 L0 12 Z" fill="#E3C68B" />
-        </marker>
       </defs>
     </svg>
     <div class="mind-shell">
@@ -4234,49 +4230,73 @@ if ($view === 'map_edit') {
       <?php endif; ?>
       <div class="mind-dock-wrap">
         <nav class="mind-dock" id="mind-dock" role="toolbar" aria-label="思维导图操作工具栏">
-          <button class="dock-btn" data-action="save" data-default-label="保存" data-tip="保存（Ctrl+S）" aria-label="保存">
+          <button class="dock-btn" data-action="save" data-default-label="保存" aria-label="保存（Ctrl+S）">
             <span class="icon">💾</span>
-            <span class="label">保存</span>
+            <span class="label-group">
+              <span class="label">保存</span>
+              <span class="shortcut">Ctrl+S</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="undo" data-tip="撤销（Ctrl/⌘+Z）" aria-label="撤销操作">
+          <button class="dock-btn" data-action="undo" aria-label="撤销操作（Ctrl/⌘+Z）">
             <span class="icon">↺</span>
-            <span class="label">撤销</span>
+            <span class="label-group">
+              <span class="label">撤销</span>
+              <span class="shortcut">Ctrl/⌘+Z</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="redo" data-tip="重做（Ctrl+Shift+Z）" aria-label="重做操作">
+          <button class="dock-btn" data-action="redo" aria-label="重做操作（Ctrl+Shift+Z）">
             <span class="icon">↻</span>
-            <span class="label">重做</span>
+            <span class="label-group">
+              <span class="label">重做</span>
+              <span class="shortcut">Ctrl+Shift+Z</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="sibling" data-tip="同级节点（Enter）" aria-label="新增同级节点">
+          <button class="dock-btn" data-action="sibling" aria-label="新增同级节点（Enter）">
             <span class="icon">⧉</span>
-            <span class="label">同级</span>
+            <span class="label-group">
+              <span class="label">同级</span>
+              <span class="shortcut">Enter</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="child" data-tip="子级节点（Tab）" aria-label="新增子级节点">
+          <button class="dock-btn" data-action="child" aria-label="新增子级节点（Tab）">
             <span class="icon">↳</span>
-            <span class="label">子级</span>
+            <span class="label-group">
+              <span class="label">子级</span>
+              <span class="shortcut">Tab</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="fold" data-tip="折叠/展开（Space 或 ←/→）" aria-label="折叠或展开节点">
+          <button class="dock-btn" data-action="fold" aria-label="折叠或展开节点">
             <span class="icon" data-fold-icon>⇅</span>
-            <span class="label" data-fold-label>折叠</span>
+            <span class="label-group">
+              <span class="label" data-fold-label>折叠</span>
+              <span class="shortcut" data-fold-shortcut>Space 或 ←/→</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="attach" data-tip="上传附件" aria-label="上传附件">
+          <button class="dock-btn" data-action="attach" aria-label="上传附件">
             <span class="icon">📎</span>
             <span class="label">附件</span>
           </button>
-          <button class="dock-btn" data-action="manage-attachments" data-tip="附件管理（Ctrl+Shift+A）" aria-label="附件管理">
+          <button class="dock-btn" data-action="manage-attachments" aria-label="附件管理（Ctrl+Shift+A）">
             <span class="icon">🗂</span>
-            <span class="label">管理</span>
+            <span class="label-group">
+              <span class="label">管理</span>
+              <span class="shortcut">Ctrl+Shift+A</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="relation" data-tip="建立关联" aria-label="关联节点">
+          <button class="dock-btn" data-action="relation" aria-label="关联节点">
             <span class="icon">🪢</span>
             <span class="label">关联</span>
           </button>
-          <button class="dock-btn" data-action="link" data-tip="新增链接" aria-label="新增链接">
+          <button class="dock-btn" data-action="link" aria-label="新增链接">
             <span class="icon">🔗</span>
             <span class="label">链接</span>
           </button>
-          <button class="dock-btn danger" data-action="delete" data-tip="删除（Backspace/Del）" aria-label="删除节点">
+          <button class="dock-btn danger" data-action="delete" aria-label="删除节点（Backspace/Del）">
             <span class="icon">🗑</span>
-            <span class="label">删除</span>
+            <span class="label-group">
+              <span class="label">删除</span>
+              <span class="shortcut">Backspace/Del</span>
+            </span>
           </button>
         </nav>
       </div>
@@ -6235,24 +6255,50 @@ if ($view === 'map_edit') {
             const core=document.createElementNS('http://www.w3.org/2000/svg','path');
             core.classList.add('relation-core');
             core.dataset.bidirectional=relation.bidirectional?'true':'false';
-            core.setAttribute('marker-end','url(#mindRelationArrow)');
-            if(relation.bidirectional){ core.setAttribute('marker-start','url(#mindRelationArrow)'); }
-            else{ core.removeAttribute('marker-start'); }
+            const pathId=`relation-path-${relation.id}`;
+            core.setAttribute('id', pathId);
             const highlight=document.createElementNS('http://www.w3.org/2000/svg','path');
             highlight.classList.add('relation-highlight');
             const hit=document.createElementNS('http://www.w3.org/2000/svg','path');
             hit.classList.add('relation-hit');
             hit.setAttribute('fill','none');
             hit.setAttribute('stroke','transparent');
+            const direction=document.createElementNS('http://www.w3.org/2000/svg','text');
+            direction.classList.add('relation-direction');
+            const directionPath=document.createElementNS('http://www.w3.org/2000/svg','textPath');
+            directionPath.setAttribute('href', `#${pathId}`);
+            directionPath.setAttributeNS('http://www.w3.org/1999/xlink','xlink:href', `#${pathId}`);
+            directionPath.setAttribute('startOffset','0%');
+            directionPath.setAttribute('method','align');
+            directionPath.setAttribute('spacing','auto');
+            directionPath.setAttribute('lengthAdjust','spacingAndGlyphs');
+            direction.appendChild(directionPath);
+            let reverseDirection=null;
+            let reverseDirectionPath=null;
+            if(relation.bidirectional){
+              reverseDirection=document.createElementNS('http://www.w3.org/2000/svg','text');
+              reverseDirection.classList.add('relation-direction','reverse');
+              reverseDirectionPath=document.createElementNS('http://www.w3.org/2000/svg','textPath');
+              reverseDirectionPath.setAttribute('href', `#${pathId}`);
+              reverseDirectionPath.setAttributeNS('http://www.w3.org/1999/xlink','xlink:href', `#${pathId}`);
+              reverseDirectionPath.setAttribute('startOffset','100%');
+              reverseDirectionPath.setAttribute('text-anchor','end');
+              reverseDirectionPath.setAttribute('method','align');
+              reverseDirectionPath.setAttribute('spacing','auto');
+              reverseDirectionPath.setAttribute('lengthAdjust','spacingAndGlyphs');
+              reverseDirection.appendChild(reverseDirectionPath);
+            }
             if(this.selectedRelationId && this.selectedRelationId===relation.id){
               group.dataset.selected='true';
             }
             group.appendChild(shadow);
             group.appendChild(core);
             group.appendChild(highlight);
+            group.appendChild(direction);
+            if(reverseDirection){ group.appendChild(reverseDirection); }
             group.appendChild(hit);
             this.relationLayer.appendChild(group);
-            this.relationRegistry.set(relation.id,{group,shadow,core,highlight,hit,relation});
+            this.relationRegistry.set(relation.id,{group,shadow,core,highlight,hit,relation,direction,directionPath,reverseDirection,reverseDirectionPath});
             const handleSelect=evt=>{
               if(evt){ evt.stopPropagation(); }
               const isMouse=evt && evt.pointerType==='mouse';
@@ -6579,51 +6625,48 @@ if ($view === 'map_edit') {
           };
           const startSide=determineSide(fromNode);
           const endSide=determineSide(toNode);
-          const adjustVector=(vector, side)=>{
-            if(!vector) return vector;
-            if(!side) return {x:vector.x,y:vector.y};
-            const biasBase=Math.hypot(vector.x, vector.y) || 1;
-            const bias=Math.min(Math.max(biasBase*0.35, 18), 72);
-            return {x:vector.x + side*bias, y:vector.y};
-          };
-          const startVector={x:endCenter.x-startCenter.x,y:endCenter.y-startCenter.y};
-          const endVector={x:startCenter.x-endCenter.x,y:startCenter.y-endCenter.y};
-          const startInner=this.computeNodeBoundaryPoint(fromNode, adjustVector(startVector, startSide), 8);
-          const endInner=this.computeNodeBoundaryPoint(toNode, adjustVector(endVector, endSide), 8);
-          if(!startInner || !endInner) return;
-          let vector={x:endInner.x-startInner.x,y:endInner.y-startInner.y};
+          const startAnchor=this.chooseVerticalAnchor(fromNode, toNode);
+          const endAnchor=this.chooseVerticalAnchor(toNode, fromNode);
+          if(!startAnchor || !endAnchor) return;
+          let startPoint={x:startAnchor.x,y:startAnchor.y};
+          let endPoint={x:endAnchor.x,y:endAnchor.y};
+          let vector={x:endPoint.x-startPoint.x,y:endPoint.y-startPoint.y};
           let segmentLength=Math.hypot(vector.x, vector.y);
           if(segmentLength<0.001){
-            vector={x:endCenter.x-startCenter.x,y:endCenter.y-startCenter.y};
+            startPoint={x:startCenter.x,y:startCenter.y};
+            endPoint={x:endCenter.x,y:endCenter.y};
+            vector={x:endPoint.x-startPoint.x,y:endPoint.y-startPoint.y};
             segmentLength=Math.hypot(vector.x, vector.y);
             if(segmentLength<0.001) return;
-            startInner={x:startCenter.x,y:startCenter.y};
-            endInner={x:endCenter.x,y:endCenter.y};
           }
-          const norm={x:vector.x/segmentLength,y:vector.y/segmentLength};
-          const arrowBase=Math.min(22, Math.max(10, segmentLength*0.18));
-          const halfDistance=segmentLength/2;
-          const clearanceLimit=Math.max(0, halfDistance - 6);
-          const effectiveClearance=Math.max(0, Math.min(arrowBase, clearanceLimit, segmentLength - 8));
-          const endClearance=effectiveClearance;
-          const startClearance=relation.bidirectional ? effectiveClearance : 0;
-          const startPoint={x:startInner.x - norm.x*startClearance,y:startInner.y - norm.y*startClearance};
-          const endPoint={x:endInner.x - norm.x*endClearance,y:endInner.y - norm.y*endClearance};
           const dx=endPoint.x-startPoint.x;
           const dy=endPoint.y-startPoint.y;
           const distance=Math.hypot(dx,dy) || 1;
           const baseNormal={x:distance?-dy/distance:0,y:distance?dx/distance:0};
           const tangentLength=Math.min(96, Math.max(24, distance*0.28));
           const curvature=Math.min(160, Math.max(26, distance*0.42));
-          const verticalHint=Math.abs(dy)>4 ? Math.sign(dy) : 0;
-          const fallbackHorizontal=(()=>{ const direct=Math.sign(dx); if(direct) return direct; return (startSide||endSide||1); })();
-          const buildTangent=(side, fallback, normalBias)=>{
+          let verticalHint=Math.abs(dy)>4 ? Math.sign(dy) : 0;
+          if(!verticalHint){
+            const orientationBias=anchor=>{
+              if(!anchor || !anchor.orientation) return 0;
+              return anchor.orientation==='top'?-1:anchor.orientation==='bottom'?1:0;
+            };
+            const combined=orientationBias(startAnchor) || orientationBias(endAnchor);
+            if(combined){ verticalHint=combined; }
+          }
+          const fallbackHorizontal=(()=>{ const direct=Math.sign(dx); if(direct) return direct; return (startSide||endSide||1);})();
+          const buildTangent=(side, fallback, normalBias, orientation)=>{
             let horizontal=side;
             if(horizontal===0){ horizontal=fallback; }
             if(horizontal===0){ horizontal=fallback>=0?1:-1; }
             let vertical=verticalHint ? verticalHint*0.6 : normalBias*0.6;
+            if(orientation==='top'){ vertical-=1.2; }
+            else if(orientation==='bottom'){ vertical+=1.2; }
             const len=Math.hypot(horizontal, vertical);
-            if(len===0){ return {x:horizontal||0,y:vertical||0}; }
+            if(len===0){
+              const fallbackVertical=orientation==='top'?-1:orientation==='bottom'?1:normalBias||0;
+              return {x:horizontal||0,y:fallbackVertical};
+            }
             return {x:horizontal/len,y:vertical/len};
           };
           const bezierPoint=(t,p0,p1,p2,p3)=>{
@@ -6639,8 +6682,8 @@ if ($view === 'map_edit') {
           const evaluatePath=normalSign=>{
             const normalX=baseNormal.x*normalSign;
             const normalY=baseNormal.y*normalSign;
-            const startTangent=buildTangent(startSide, fallbackHorizontal, normalSign||1);
-            const endTangent=buildTangent(endSide, fallbackHorizontal, normalSign||1);
+            const startTangent=buildTangent(startSide, fallbackHorizontal, normalSign||1, startAnchor.orientation);
+            const endTangent=buildTangent(endSide, fallbackHorizontal, normalSign||1, endAnchor.orientation);
             const startCtrlBase={
               x:startPoint.x + startTangent.x*tangentLength,
               y:startPoint.y + startTangent.y*tangentLength
@@ -6681,34 +6724,59 @@ if ($view === 'map_edit') {
           entry.highlight.setAttribute('d', pathData);
           if(entry.hit){ entry.hit.setAttribute('d', pathData); }
           entry.core.dataset.bidirectional=relation && relation.bidirectional?'true':'false';
-          if(relation.bidirectional){ entry.core.setAttribute('marker-start','url(#mindRelationArrow)'); }
-          else{ entry.core.removeAttribute('marker-start'); }
+          const pathLength=entry.core.getTotalLength();
+          const updateDirectionGlyphs=(target, targetPath, glyph)=>{
+            if(!target || !targetPath) return;
+            if(!Number.isFinite(pathLength) || pathLength<18){
+              target.style.display='none';
+              return;
+            }
+            const density=12;
+            const count=Math.max(2, Math.ceil(pathLength/density));
+            targetPath.textContent=glyph.repeat(count);
+            targetPath.setAttribute('textLength', pathLength);
+            targetPath.setAttribute('lengthAdjust','spacingAndGlyphs');
+            target.style.display='';
+          };
+          if(entry.direction && entry.directionPath){
+            updateDirectionGlyphs(entry.direction, entry.directionPath, '›');
+          }
+          if(entry.reverseDirection && entry.reverseDirectionPath){
+            if(relation.bidirectional){
+              updateDirectionGlyphs(entry.reverseDirection, entry.reverseDirectionPath, '‹');
+            }else{
+              entry.reverseDirection.style.display='none';
+            }
+          }
           entry.relation=relation;
         }
-        computeNodeBoundaryPoint(node, directionVector, padding){
-          if(!node || !directionVector) return null;
-          const width=Math.max(1, node.width || (node.el?node.el.offsetWidth:0) || 0);
-          const height=Math.max(1, node.height || (node.el?node.el.offsetHeight:0) || 0);
-          const halfW=width/2 + (padding||0);
-          const halfH=height/2 + (padding||0);
-          let dx=typeof directionVector.x==='number'?directionVector.x:0;
-          let dy=typeof directionVector.y==='number'?directionVector.y:0;
-          const tiny=1e-6;
-          if(Math.abs(dx)<tiny && Math.abs(dy)<tiny){
-            return {x:node.absX,y:node.absY};
-          }
-          if(Math.abs(dx)<tiny){ dx=dx>=0?tiny:-tiny; }
-          if(Math.abs(dy)<tiny){ dy=dy>=0?tiny:-tiny; }
-          const absDx=Math.abs(dx);
-          const absDy=Math.abs(dy);
-          let scale;
-          if(absDx<tiny){ scale=halfH/absDy; }
-          else if(absDy<tiny){ scale=halfW/absDx; }
-          else{ scale=Math.min(halfW/absDx, halfH/absDy); }
-          return {
-            x:node.absX + dx*scale,
-            y:node.absY + dy*scale,
+        chooseVerticalAnchor(node, counterpart){
+          if(!node) return null;
+          if(!node.anchors) this.updateAnchors(node);
+          const anchors=node.anchors||{};
+          const cloneAnchor=(anchor, orientation)=>{
+            if(!anchor) return null;
+            return {x:anchor.x,y:anchor.y,orientation};
           };
+          const top=cloneAnchor(anchors.top,'top');
+          const bottom=cloneAnchor(anchors.bottom,'bottom');
+          const center=cloneAnchor(anchors.center,'center');
+          let targetY=null;
+          if(counterpart){
+            if(counterpart.anchors && counterpart.anchors.center && Number.isFinite(counterpart.anchors.center.y)){
+              targetY=counterpart.anchors.center.y;
+            }else if(Number.isFinite(counterpart.absY)){
+              targetY=counterpart.absY;
+            }
+          }
+          if(targetY===null && center){ targetY=center.y; }
+          if(top && bottom && targetY!==null){
+            const topDist=Math.abs(top.y-targetY);
+            const bottomDist=Math.abs(bottom.y-targetY);
+            if(bottomDist<topDist){ return bottom; }
+            return top;
+          }
+          return top || bottom || center;
         }
         updateRelationsForNode(node){
           if(!node || !this.relationRegistry || !this.relationRegistry.size) return;
@@ -7538,6 +7606,7 @@ if ($view === 'map_edit') {
       const dockFoldButton=dock ? dock.querySelector('.dock-btn[data-action="fold"]') : null;
       const dockFoldLabel=dockFoldButton ? dockFoldButton.querySelector('[data-fold-label]') : null;
       const dockFoldIcon=dockFoldButton ? dockFoldButton.querySelector('[data-fold-icon]') : null;
+      const dockFoldShortcut=dockFoldButton ? dockFoldButton.querySelector('[data-fold-shortcut]') : null;
       const exportOverlay=document.getElementById('mind-export-overlay');
       const mapIo=document.getElementById('map-io');
       const mapIoButton=document.getElementById('map-io-button');
@@ -7709,18 +7778,18 @@ if ($view === 'map_edit') {
         const hasChildren=!!(node && node.children && node.children.length);
         let label='折叠';
         let icon='⇅';
-        let tip='折叠/展开（Space 或 ←/→）';
+        let shortcut='Space 或 ←/→';
         if(hasChildren){
           const collapsed=node.expanded===false;
           label=collapsed?'展开':'折叠';
           icon=collapsed?'⤴':'⤵';
-          tip=collapsed?'展开（Space 或 →）':'折叠（Space 或 ←）';
+          shortcut=collapsed?'Space 或 →':'Space 或 ←';
         }
         if(dockFoldLabel){ dockFoldLabel.textContent=label; }
         if(dockFoldIcon){ dockFoldIcon.textContent=icon; }
-        dockFoldButton.dataset.tip=tip;
+        if(dockFoldShortcut){ dockFoldShortcut.textContent=shortcut; }
         dockFoldButton.disabled=!hasChildren;
-        dockFoldButton.setAttribute('aria-label', hasChildren ? `${label}节点` : '折叠或展开节点');
+        dockFoldButton.setAttribute('aria-label', hasChildren ? `${label}节点（${shortcut}）` : '折叠或展开节点');
       }
       function restoreMindSnapshot(snapshot){
         if(!snapshot || !snapshot.tree) return false;


### PR DESCRIPTION
## Summary
- 使用节点上下锚点重绘关联线，并以 `›/‹` 文本纹理标示方向，去除原有箭头 marker。
- 为关联线新增方向文本样式，确保主题风格一致。
- 重构工具栏按钮结构，将快捷键信息内嵌于按钮并同步折叠按钮提示。

## Testing
- php -l memo.php

------
https://chatgpt.com/codex/tasks/task_e_68e654e89e1c8328ab276bc53121b31d