### PR TITLE
feat: redesign relation arrows and dock shortcuts

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -3970,6 +3970,8 @@ if ($view === 'map_edit') {
       .mind-relations .relation-shadow{stroke:rgba(122,94,54,.55);stroke-width:2.1;opacity:.65;filter:url(#mindSoftGlow);transition:stroke var(--transition),opacity var(--transition)}
       .mind-relations .relation-core{stroke:url(#mindGoldTrace);stroke-width:1.6;filter:url(#mindSoftGlow);transition:stroke var(--transition),stroke-width var(--transition)}
       .mind-relations .relation-highlight{stroke:rgba(255,242,218,.32);stroke-width:0.8;transition:stroke var(--transition),stroke-width var(--transition),opacity var(--transition)}
+      .mind-relations .relation-direction{font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.26em;text-transform:uppercase;fill:rgba(255,242,218,.82);stroke:rgba(12,16,18,.45);stroke-width:.6;paint-order:stroke fill;pointer-events:none;filter:url(#mindSoftGlow)}
+      .mind-relations .relation-direction textPath{dominant-baseline:middle}
       .mind-relations .relation-core{pointer-events:stroke;cursor:pointer}
       .mind-relations .relation-highlight{pointer-events:none}
       .mind-relations .relation-group[data-selected="true"]{filter:drop-shadow(0 0 6px rgba(191,242,255,.45)) drop-shadow(0 0 18px rgba(191,242,255,.3))}
@@ -4010,15 +4012,11 @@ if ($view === 'map_edit') {
       .mind-dock-wrap{position:fixed;left:50%;bottom:calc(var(--safe-bottom) + 18px);transform:translateX(-50%);pointer-events:none;z-index:120;max-width:min(calc(100vw - 32px - var(--safe-left) - var(--safe-right)),1120px);width:100%;display:flex;justify-content:center}
       .mind-dock{pointer-events:auto;display:flex;flex-wrap:nowrap;align-items:stretch;justify-content:center;gap:14px;padding:16px 24px;border-radius:32px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.85));border:1px solid rgba(201,168,106,.32);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 32px rgba(227,198,139,.12) inset;backdrop-filter:blur(12px);position:relative;width:100%;max-width:100%;box-sizing:border-box;touch-action:pan-x pan-y;flex:0 1 auto;margin:0 auto;overflow-x:auto;scrollbar-width:none;-webkit-overflow-scrolling:touch;overscroll-behavior-x:contain}
       .mind-dock::-webkit-scrollbar{display:none}
-      .dock-btn{position:relative;display:grid;grid-template-rows:auto auto;align-items:center;justify-items:center;height:66px;border-radius:18px;padding:8px 6px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 clamp(90px,9vw,132px);min-width:74px;max-width:148px}
-      .dock-btn .icon{font-size:20px}
+      .dock-btn{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;height:66px;border-radius:18px;padding:10px 8px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 clamp(90px,9vw,132px);min-width:74px;max-width:148px}
+      .dock-btn .icon{font-size:20px;line-height:1}
+      .dock-btn .label-group{display:flex;flex-direction:column;align-items:center;gap:2px;line-height:1}
       .dock-btn .label{font-size:12px}
-      @media (hover:hover) and (pointer:fine){
-        .dock-btn[data-tip]::after{content:attr(data-tip);position:absolute;bottom:100%;left:50%;transform:translate(-50%,6px);padding:6px 10px;border-radius:12px;border:1px solid rgba(201,168,106,.38);background:rgba(12,16,18,.92);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;white-space:nowrap;opacity:0;pointer-events:none;transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease);box-shadow:0 12px 28px rgba(0,0,0,.45)}
-        .dock-btn[data-tip]::before{content:"";position:absolute;bottom:100%;left:50%;transform:translate(-50%,6px);border-width:6px;border-style:solid;border-color:rgba(12,16,18,.92) transparent transparent transparent;opacity:0;transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
-        .dock-btn[data-tip]:hover::after,.dock-btn[data-tip]:focus-visible::after{opacity:1;transform:translate(-50%,-4px)}
-        .dock-btn[data-tip]:hover::before,.dock-btn[data-tip]:focus-visible::before{opacity:1;transform:translate(-50%,-4px)}
-      }
+      .dock-btn .shortcut{font:600 10px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase;color:rgba(227,198,139,.78);opacity:.88}
       .dock-btn:hover{transform:translateY(-3px);border-color:var(--gold-500);background:rgba(201,168,106,.16);box-shadow:0 0 26px rgba(227,198,139,.18)}
       .dock-btn:active{transform:translateY(-1px)}
       .dock-btn:focus-visible{outline:3px solid rgba(75,195,209,.35);outline-offset:2px}
@@ -4186,9 +4184,6 @@ if ($view === 'map_edit') {
             <feMergeNode in="SourceGraphic" />
           </feMerge>
         </filter>
-        <marker id="mindRelationArrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto" markerUnits="strokeWidth">
-          <path d="M0 0 L12 6 L0 12 Z" fill="#E3C68B" />
-        </marker>
       </defs>
     </svg>
     <div class="mind-shell">
@@ -4234,49 +4229,79 @@ if ($view === 'map_edit') {
       <?php endif; ?>
       <div class="mind-dock-wrap">
         <nav class="mind-dock" id="mind-dock" role="toolbar" aria-label="思维导图操作工具栏">
-          <button class="dock-btn" data-action="save" data-default-label="保存" data-tip="保存（Ctrl+S）" aria-label="保存">
+          <button class="dock-btn" data-action="save" data-default-label="保存" data-shortcut="Ctrl+S" aria-label="保存（Ctrl+S）">
             <span class="icon">💾</span>
-            <span class="label">保存</span>
+            <span class="label-group">
+              <span class="label">保存</span>
+              <span class="shortcut">Ctrl+S</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="undo" data-tip="撤销（Ctrl/⌘+Z）" aria-label="撤销操作">
+          <button class="dock-btn" data-action="undo" data-shortcut="Ctrl/⌘+Z" aria-label="撤销操作（Ctrl/⌘+Z）">
             <span class="icon">↺</span>
-            <span class="label">撤销</span>
+            <span class="label-group">
+              <span class="label">撤销</span>
+              <span class="shortcut">Ctrl/⌘+Z</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="redo" data-tip="重做（Ctrl+Shift+Z）" aria-label="重做操作">
+          <button class="dock-btn" data-action="redo" data-shortcut="Ctrl+Shift+Z" aria-label="重做操作（Ctrl+Shift+Z）">
             <span class="icon">↻</span>
-            <span class="label">重做</span>
+            <span class="label-group">
+              <span class="label">重做</span>
+              <span class="shortcut">Ctrl+Shift+Z</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="sibling" data-tip="同级节点（Enter）" aria-label="新增同级节点">
+          <button class="dock-btn" data-action="sibling" data-shortcut="Enter" aria-label="新增同级节点（Enter）">
             <span class="icon">⧉</span>
-            <span class="label">同级</span>
+            <span class="label-group">
+              <span class="label">同级</span>
+              <span class="shortcut">Enter</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="child" data-tip="子级节点（Tab）" aria-label="新增子级节点">
+          <button class="dock-btn" data-action="child" data-shortcut="Tab" aria-label="新增子级节点（Tab）">
             <span class="icon">↳</span>
-            <span class="label">子级</span>
+            <span class="label-group">
+              <span class="label">子级</span>
+              <span class="shortcut">Tab</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="fold" data-tip="折叠/展开（Space 或 ←/→）" aria-label="折叠或展开节点">
+          <button class="dock-btn" data-action="fold" data-shortcut="Space / ← →" aria-label="折叠或展开节点（Space / ← →）">
             <span class="icon" data-fold-icon>⇅</span>
-            <span class="label" data-fold-label>折叠</span>
+            <span class="label-group">
+              <span class="label" data-fold-label>折叠</span>
+              <span class="shortcut" data-fold-shortcut>Space / ← →</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="attach" data-tip="上传附件" aria-label="上传附件">
+          <button class="dock-btn" data-action="attach" aria-label="上传附件">
             <span class="icon">📎</span>
-            <span class="label">附件</span>
+            <span class="label-group">
+              <span class="label">附件</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="manage-attachments" data-tip="附件管理（Ctrl+Shift+A）" aria-label="附件管理">
+          <button class="dock-btn" data-action="manage-attachments" data-shortcut="Ctrl+Shift+A" aria-label="附件管理（Ctrl+Shift+A）">
             <span class="icon">🗂</span>
-            <span class="label">管理</span>
+            <span class="label-group">
+              <span class="label">管理</span>
+              <span class="shortcut">Ctrl+Shift+A</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="relation" data-tip="建立关联" aria-label="关联节点">
+          <button class="dock-btn" data-action="relation" aria-label="关联节点">
             <span class="icon">🪢</span>
-            <span class="label">关联</span>
+            <span class="label-group">
+              <span class="label">关联</span>
+            </span>
           </button>
-          <button class="dock-btn" data-action="link" data-tip="新增链接" aria-label="新增链接">
+          <button class="dock-btn" data-action="link" aria-label="新增链接">
             <span class="icon">🔗</span>
-            <span class="label">链接</span>
+            <span class="label-group">
+              <span class="label">链接</span>
+            </span>
           </button>
-          <button class="dock-btn danger" data-action="delete" data-tip="删除（Backspace/Del）" aria-label="删除节点">
+          <button class="dock-btn danger" data-action="delete" data-shortcut="Backspace / Del" aria-label="删除节点（Backspace / Del）">
             <span class="icon">🗑</span>
-            <span class="label">删除</span>
+            <span class="label-group">
+              <span class="label">删除</span>
+              <span class="shortcut">Backspace / Del</span>
+            </span>
           </button>
         </nav>
       </div>
@@ -6235,11 +6260,20 @@ if ($view === 'map_edit') {
             const core=document.createElementNS('http://www.w3.org/2000/svg','path');
             core.classList.add('relation-core');
             core.dataset.bidirectional=relation.bidirectional?'true':'false';
-            core.setAttribute('marker-end','url(#mindRelationArrow)');
-            if(relation.bidirectional){ core.setAttribute('marker-start','url(#mindRelationArrow)'); }
-            else{ core.removeAttribute('marker-start'); }
+            const pathId=`relation-path-${String(relation.id).replace(/[^a-zA-Z0-9_-]/g,'_')}`;
+            core.setAttribute('id', pathId);
             const highlight=document.createElementNS('http://www.w3.org/2000/svg','path');
             highlight.classList.add('relation-highlight');
+            const direction=document.createElementNS('http://www.w3.org/2000/svg','text');
+            direction.classList.add('relation-direction');
+            direction.setAttribute('aria-hidden','true');
+            const directionPath=document.createElementNS('http://www.w3.org/2000/svg','textPath');
+            directionPath.setAttribute('startOffset','0%');
+            directionPath.setAttribute('method','align');
+            directionPath.setAttribute('spacing','auto');
+            directionPath.setAttributeNS('http://www.w3.org/1999/xlink','xlink:href',`#${pathId}`);
+            directionPath.setAttribute('href',`#${pathId}`);
+            direction.appendChild(directionPath);
             const hit=document.createElementNS('http://www.w3.org/2000/svg','path');
             hit.classList.add('relation-hit');
             hit.setAttribute('fill','none');
@@ -6250,9 +6284,10 @@ if ($view === 'map_edit') {
             group.appendChild(shadow);
             group.appendChild(core);
             group.appendChild(highlight);
+            group.appendChild(direction);
             group.appendChild(hit);
             this.relationLayer.appendChild(group);
-            this.relationRegistry.set(relation.id,{group,shadow,core,highlight,hit,relation});
+            this.relationRegistry.set(relation.id,{group,shadow,core,highlight,hit,direction,directionPath,relation});
             const handleSelect=evt=>{
               if(evt){ evt.stopPropagation(); }
               const isMouse=evt && evt.pointerType==='mouse';
@@ -6546,6 +6581,56 @@ if ($view === 'map_edit') {
             btn.style.top=`${screenY}px`;
           }
         }
+        chooseVerticalAnchor(node, counterpart){
+          if(!node) return {point:null, orientation:0};
+          if(!node.anchors) this.updateAnchors(node);
+          if(counterpart && !counterpart.anchors) this.updateAnchors(counterpart);
+          const anchors=node.anchors || {};
+          const center=anchors.center && Number.isFinite(anchors.center.x) && Number.isFinite(anchors.center.y)
+            ? {x:anchors.center.x,y:anchors.center.y}
+            : (Number.isFinite(node.absX) && Number.isFinite(node.absY) ? {x:node.absX,y:node.absY} : null);
+          const rawHeight=Number.isFinite(node.height) ? node.height : (node.el ? node.el.offsetHeight : 0) || 0;
+          const halfHeight=Math.max(0, rawHeight/2);
+          const fallbackTop=center ? {x:center.x,y:center.y - halfHeight} : null;
+          const fallbackBottom=center ? {x:center.x,y:center.y + halfHeight} : null;
+          const top=anchors.top ? {x:anchors.top.x,y:anchors.top.y} : fallbackTop;
+          const bottom=anchors.bottom ? {x:anchors.bottom.x,y:anchors.bottom.y} : fallbackBottom;
+          const counterpartCenter=(counterpart && counterpart.anchors && counterpart.anchors.center && Number.isFinite(counterpart.anchors.center.x) && Number.isFinite(counterpart.anchors.center.y))
+            ? {x:counterpart.anchors.center.x,y:counterpart.anchors.center.y}
+            : (counterpart && Number.isFinite(counterpart.absX) && Number.isFinite(counterpart.absY) ? {x:counterpart.absX,y:counterpart.absY} : null);
+          let orientation=1;
+          let point=bottom || top || center;
+          if(top && bottom && counterpartCenter){
+            const distTop=Math.abs(top.y - counterpartCenter.y);
+            const distBottom=Math.abs(bottom.y - counterpartCenter.y);
+            if(distTop <= distBottom){
+              orientation=-1;
+              point=top;
+            }else{
+              orientation=1;
+              point=bottom;
+            }
+          }else if(top && !bottom){
+            orientation=-1;
+            point=top;
+          }else if(bottom && !top){
+            orientation=1;
+            point=bottom;
+          }else if(center && counterpartCenter){
+            orientation=counterpartCenter.y < center.y ? -1 : 1;
+            point=orientation===-1 ? (top || center) : (bottom || center);
+          }else if(point){
+            if(center && counterpartCenter){
+              orientation=counterpartCenter.y < center.y ? -1 : 1;
+            }
+          }else{
+            orientation=0;
+          }
+          if(!point){
+            return {point:null, orientation:0};
+          }
+          return {point:{x:point.x,y:point.y}, orientation};
+        }
         updateRelationPath(relation){
           if(!relation) return;
           const entry=this.relationRegistry ? this.relationRegistry.get(relation.id) : null;
@@ -6579,17 +6664,26 @@ if ($view === 'map_edit') {
           };
           const startSide=determineSide(fromNode);
           const endSide=determineSide(toNode);
-          const adjustVector=(vector, side)=>{
-            if(!vector) return vector;
-            if(!side) return {x:vector.x,y:vector.y};
-            const biasBase=Math.hypot(vector.x, vector.y) || 1;
-            const bias=Math.min(Math.max(biasBase*0.35, 18), 72);
-            return {x:vector.x + side*bias, y:vector.y};
+          const measureAnchorOffset=node=>{
+            const raw=Number.isFinite(node.height) ? node.height : (node.el ? node.el.offsetHeight : 0) || 0;
+            return Math.min(28, Math.max(10, raw*0.18 || 12));
           };
-          const startVector={x:endCenter.x-startCenter.x,y:endCenter.y-startCenter.y};
-          const endVector={x:startCenter.x-endCenter.x,y:startCenter.y-endCenter.y};
-          const startInner=this.computeNodeBoundaryPoint(fromNode, adjustVector(startVector, startSide), 8);
-          const endInner=this.computeNodeBoundaryPoint(toNode, adjustVector(endVector, endSide), 8);
+          const offsetAnchorPoint=(node, anchor)=>{
+            if(!anchor || !anchor.point) return null;
+            const orientation=anchor.orientation || 0;
+            const base={x:anchor.point.x,y:anchor.point.y};
+            if(!orientation){ return base; }
+            const offset=measureAnchorOffset(node);
+            return {x:base.x, y:base.y + orientation*offset};
+          };
+          const startAnchor=this.chooseVerticalAnchor(fromNode, toNode);
+          const endAnchor=this.chooseVerticalAnchor(toNode, fromNode);
+          let startInner=offsetAnchorPoint(fromNode, startAnchor);
+          let endInner=offsetAnchorPoint(toNode, endAnchor);
+          if(!startInner || !endInner){
+            startInner=startAnchor && startAnchor.point ? {x:startAnchor.point.x,y:startAnchor.point.y} : (startCenter?{x:startCenter.x,y:startCenter.y}:null);
+            endInner=endAnchor && endAnchor.point ? {x:endAnchor.point.x,y:endAnchor.point.y} : (endCenter?{x:endCenter.x,y:endCenter.y}:null);
+          }
           if(!startInner || !endInner) return;
           let vector={x:endInner.x-startInner.x,y:endInner.y-startInner.y};
           let segmentLength=Math.hypot(vector.x, vector.y);
@@ -6601,10 +6695,10 @@ if ($view === 'map_edit') {
             endInner={x:endCenter.x,y:endCenter.y};
           }
           const norm={x:vector.x/segmentLength,y:vector.y/segmentLength};
-          const arrowBase=Math.min(22, Math.max(10, segmentLength*0.18));
+          const arrowBase=Math.min(28, Math.max(12, segmentLength*0.24));
           const halfDistance=segmentLength/2;
-          const clearanceLimit=Math.max(0, halfDistance - 6);
-          const effectiveClearance=Math.max(0, Math.min(arrowBase, clearanceLimit, segmentLength - 8));
+          const clearanceLimit=Math.max(0, halfDistance - 8);
+          const effectiveClearance=Math.max(0, Math.min(arrowBase, clearanceLimit, segmentLength - 10));
           const endClearance=effectiveClearance;
           const startClearance=relation.bidirectional ? effectiveClearance : 0;
           const startPoint={x:startInner.x - norm.x*startClearance,y:startInner.y - norm.y*startClearance};
@@ -6613,8 +6707,9 @@ if ($view === 'map_edit') {
           const dy=endPoint.y-startPoint.y;
           const distance=Math.hypot(dx,dy) || 1;
           const baseNormal={x:distance?-dy/distance:0,y:distance?dx/distance:0};
-          const tangentLength=Math.min(96, Math.max(24, distance*0.28));
-          const curvature=Math.min(160, Math.max(26, distance*0.42));
+          const tangentLength=Math.min(120, Math.max(32, distance*0.34));
+          const curvature=Math.min(200, Math.max(38, distance*0.54));
+          const arrowDirectionChar=dx>=0 ? '›' : '‹';
           const verticalHint=Math.abs(dy)>4 ? Math.sign(dy) : 0;
           const fallbackHorizontal=(()=>{ const direct=Math.sign(dx); if(direct) return direct; return (startSide||endSide||1); })();
           const buildTangent=(side, fallback, normalBias)=>{
@@ -6681,34 +6776,41 @@ if ($view === 'map_edit') {
           entry.highlight.setAttribute('d', pathData);
           if(entry.hit){ entry.hit.setAttribute('d', pathData); }
           entry.core.dataset.bidirectional=relation && relation.bidirectional?'true':'false';
-          if(relation.bidirectional){ entry.core.setAttribute('marker-start','url(#mindRelationArrow)'); }
-          else{ entry.core.removeAttribute('marker-start'); }
-          entry.relation=relation;
-        }
-        computeNodeBoundaryPoint(node, directionVector, padding){
-          if(!node || !directionVector) return null;
-          const width=Math.max(1, node.width || (node.el?node.el.offsetWidth:0) || 0);
-          const height=Math.max(1, node.height || (node.el?node.el.offsetHeight:0) || 0);
-          const halfW=width/2 + (padding||0);
-          const halfH=height/2 + (padding||0);
-          let dx=typeof directionVector.x==='number'?directionVector.x:0;
-          let dy=typeof directionVector.y==='number'?directionVector.y:0;
-          const tiny=1e-6;
-          if(Math.abs(dx)<tiny && Math.abs(dy)<tiny){
-            return {x:node.absX,y:node.absY};
+          if(entry.directionPath){
+            if(entry.core.id){
+              const href=`#${entry.core.id}`;
+              entry.directionPath.setAttribute('href', href);
+              entry.directionPath.setAttributeNS('http://www.w3.org/1999/xlink','xlink:href', href);
+            }
+            const totalLength=typeof entry.core.getTotalLength==='function' ? entry.core.getTotalLength() : 0;
+            let arrowString='';
+            if(totalLength>0){
+              const spacing=relation.bidirectional ? 22 : 16;
+              let count=Math.max(relation.bidirectional?4:3, Math.floor(totalLength/spacing));
+              if(relation.bidirectional && count%2!==0){ count+=1; }
+              if(relation.bidirectional){
+                const pattern='›‹';
+                arrowString=pattern.repeat(Math.ceil(count/pattern.length)).slice(0,count);
+              }else{
+                arrowString=arrowDirectionChar.repeat(count);
+              }
+            }
+            if(!arrowString){ arrowString=relation.bidirectional ? '›‹' : arrowDirectionChar.repeat(2); }
+            if(entry.direction){
+              if(arrowString){ entry.direction.removeAttribute('display'); }
+              else{ entry.direction.setAttribute('display','none'); }
+            }
+            entry.directionPath.textContent=arrowString;
+            if(arrowString){
+              const textLength=Math.max(12, totalLength - 8);
+              entry.directionPath.setAttribute('textLength', textLength);
+              entry.directionPath.setAttribute('lengthAdjust','spacing');
+            }else{
+              entry.directionPath.removeAttribute('textLength');
+              entry.directionPath.removeAttribute('lengthAdjust');
+            }
           }
-          if(Math.abs(dx)<tiny){ dx=dx>=0?tiny:-tiny; }
-          if(Math.abs(dy)<tiny){ dy=dy>=0?tiny:-tiny; }
-          const absDx=Math.abs(dx);
-          const absDy=Math.abs(dy);
-          let scale;
-          if(absDx<tiny){ scale=halfH/absDy; }
-          else if(absDy<tiny){ scale=halfW/absDx; }
-          else{ scale=Math.min(halfW/absDx, halfH/absDy); }
-          return {
-            x:node.absX + dx*scale,
-            y:node.absY + dy*scale,
-          };
+          entry.relation=relation;
         }
         updateRelationsForNode(node){
           if(!node || !this.relationRegistry || !this.relationRegistry.size) return;
@@ -7538,6 +7640,7 @@ if ($view === 'map_edit') {
       const dockFoldButton=dock ? dock.querySelector('.dock-btn[data-action="fold"]') : null;
       const dockFoldLabel=dockFoldButton ? dockFoldButton.querySelector('[data-fold-label]') : null;
       const dockFoldIcon=dockFoldButton ? dockFoldButton.querySelector('[data-fold-icon]') : null;
+      const dockFoldShortcut=dockFoldButton ? dockFoldButton.querySelector('[data-fold-shortcut]') : null;
       const exportOverlay=document.getElementById('mind-export-overlay');
       const mapIo=document.getElementById('map-io');
       const mapIoButton=document.getElementById('map-io-button');
@@ -7709,18 +7812,19 @@ if ($view === 'map_edit') {
         const hasChildren=!!(node && node.children && node.children.length);
         let label='折叠';
         let icon='⇅';
-        let tip='折叠/展开（Space 或 ←/→）';
+        let shortcut='Space / ← →';
         if(hasChildren){
           const collapsed=node.expanded===false;
           label=collapsed?'展开':'折叠';
           icon=collapsed?'⤴':'⤵';
-          tip=collapsed?'展开（Space 或 →）':'折叠（Space 或 ←）';
+          shortcut=collapsed?'Space / →':'Space / ←';
         }
         if(dockFoldLabel){ dockFoldLabel.textContent=label; }
         if(dockFoldIcon){ dockFoldIcon.textContent=icon; }
-        dockFoldButton.dataset.tip=tip;
+        if(dockFoldShortcut){ dockFoldShortcut.textContent=shortcut; }
+        dockFoldButton.dataset.shortcut=shortcut;
         dockFoldButton.disabled=!hasChildren;
-        dockFoldButton.setAttribute('aria-label', hasChildren ? `${label}节点` : '折叠或展开节点');
+        dockFoldButton.setAttribute('aria-label', hasChildren ? `${label}节点（${shortcut}）` : '折叠或展开节点');
       }
       function restoreMindSnapshot(snapshot){
         if(!snapshot || !snapshot.tree) return false;


### PR DESCRIPTION
## Summary
- anchor relation connectors to vertical centers and render repeating arrow glyphs to express directionality
- replace hover tooltips with inline shortcut labels on dock buttons and update related styling and accessibility copy

## Testing
- php -l memo.php
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68e654e89e1c8328ab276bc53121b31d