### PR TITLE
优化首页性能并增强导出配置

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -248,6 +248,7 @@ function db(): PDO {
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     title TEXT NOT NULL,
     content TEXT NOT NULL,
+    outline TEXT,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
   );');
@@ -265,6 +266,19 @@ function db(): PDO {
   );');
   $pdo->exec('CREATE INDEX IF NOT EXISTS idx_mindmap_assets_map ON mindmap_assets(mindmap_id)');
   $pdo->exec('CREATE INDEX IF NOT EXISTS idx_mindmap_assets_session ON mindmap_assets(session_key)');
+  $mindmapCols=$pdo->query('PRAGMA table_info(mindmaps)')->fetchAll();
+  $mindmapColNames=array_map(fn($col)=>$col['name']??'', $mindmapCols);
+  if(!in_array('outline',$mindmapColNames,true)){
+    $pdo->exec('ALTER TABLE mindmaps ADD COLUMN outline TEXT');
+    $existingMaps=$pdo->query('SELECT id, content FROM mindmaps')->fetchAll();
+    if($existingMaps){
+      $update=$pdo->prepare('UPDATE mindmaps SET outline=? WHERE id=?');
+      foreach($existingMaps as $mapRow){
+        $outline=mindmap_outline_preview((string)$mapRow['content']);
+        $update->execute([$outline,$mapRow['id']]);
+      }
+    }
+  }
   $hasMap = (int)$pdo->query('SELECT COUNT(*) FROM mindmaps')->fetchColumn();
   if ($hasMap === 0) {
     $nowTs = now();
@@ -274,8 +288,9 @@ function db(): PDO {
       $decoded['data']['topic'] = '默认导图';
       $defaultPayload = json_encode($decoded, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     }
-    $pdo->prepare('INSERT INTO mindmaps(title, content, created_at, updated_at) VALUES(?,?,?,?)')
-        ->execute(['默认导图', $defaultPayload, $nowTs, $nowTs]);
+    $outline=mindmap_outline_preview($defaultPayload);
+    $pdo->prepare('INSERT INTO mindmaps(title, content, outline, created_at, updated_at) VALUES(?,?,?,?,?)')
+        ->execute(['默认导图', $defaultPayload, $outline, $nowTs, $nowTs]);
   }
   // 创建上传目录
   if(!is_dir(UPLOAD_DIR)) @mkdir(UPLOAD_DIR,0775,true);
@@ -364,6 +379,22 @@ function get_steps_grouped(array $item_ids): array {
   return $group;
 }
 
+function get_steps_by_time_grouped(array $item_ids): array {
+  $ids=array_values(array_unique(array_map('intval',$item_ids)));
+  if(!$ids){ return []; }
+  $pdo=db();
+  $placeholders=implode(',', array_fill(0,count($ids),'?'));
+  $st=$pdo->prepare("SELECT * FROM steps WHERE item_id IN ($placeholders) ORDER BY item_id ASC, created_at ASC, id ASC");
+  $st->execute($ids);
+  $group=[];
+  foreach($st->fetchAll() as $row){
+    $iid=(int)$row['item_id'];
+    if(!isset($group[$iid])) $group[$iid]=[];
+    $group[$iid][]=$row;
+  }
+  return $group;
+}
+
 function get_step_counts(array $item_ids): array {
   $ids=array_values(array_unique(array_map('intval',$item_ids)));
   if(!$ids){ return []; }
@@ -382,6 +413,22 @@ function get_attachment(int $id): ?array {
 
 function attachments_for_item(int $item_id): array {
   $pdo=db(); $st=$pdo->prepare('SELECT * FROM attachments WHERE item_id=? ORDER BY id DESC'); $st->execute([$item_id]); return $st->fetchAll();
+}
+
+function attachments_for_items(array $item_ids): array {
+  $ids=array_values(array_unique(array_map('intval',$item_ids)));
+  if(!$ids){ return []; }
+  $pdo=db();
+  $placeholders=implode(',', array_fill(0,count($ids),'?'));
+  $st=$pdo->prepare("SELECT * FROM attachments WHERE item_id IN ($placeholders) ORDER BY item_id ASC, id DESC");
+  $st->execute($ids);
+  $group=[];
+  foreach($st->fetchAll() as $row){
+    $iid=(int)$row['item_id'];
+    if(!isset($group[$iid])) $group[$iid]=[];
+    $group[$iid][]=$row;
+  }
+  return $group;
 }
 
 function get_mindmap_asset(int $id): ?array {
@@ -450,12 +497,12 @@ function prune_mindmap_assets(int $map_id, array $keep_ids): void {
 // —— 思维导图 ——
 function get_mindmaps(): array {
   $pdo=db();
-  return $pdo->query('SELECT * FROM mindmaps ORDER BY updated_at DESC, id DESC')->fetchAll();
+  return $pdo->query('SELECT id,title,content,outline,created_at,updated_at FROM mindmaps ORDER BY updated_at DESC, id DESC')->fetchAll();
 }
 
 function get_mindmap(int $id): ?array {
   $pdo=db();
-  $st=$pdo->prepare('SELECT * FROM mindmaps WHERE id=? LIMIT 1');
+  $st=$pdo->prepare('SELECT id,title,content,outline,created_at,updated_at FROM mindmaps WHERE id=? LIMIT 1');
   $st->execute([$id]);
   return $st->fetch() ?: null;
 }
@@ -463,8 +510,9 @@ function get_mindmap(int $id): ?array {
 function create_mindmap(string $title, string $content): array {
   $pdo=db();
   $nowTs=now();
-  $pdo->prepare('INSERT INTO mindmaps(title, content, created_at, updated_at) VALUES(?,?,?,?)')
-      ->execute([$title,$content,$nowTs,$nowTs]);
+  $outline=mindmap_outline_preview($content);
+  $pdo->prepare('INSERT INTO mindmaps(title, content, outline, created_at, updated_at) VALUES(?,?,?,?,?)')
+      ->execute([$title,$content,$outline,$nowTs,$nowTs]);
   $id=(int)$pdo->lastInsertId();
   return ['id'=>$id,'updated_at'=>$nowTs];
 }
@@ -472,8 +520,9 @@ function create_mindmap(string $title, string $content): array {
 function update_mindmap(int $id, string $title, string $content): array {
   $pdo=db();
   $nowTs=now();
-  $pdo->prepare('UPDATE mindmaps SET title=?, content=?, updated_at=? WHERE id=?')
-      ->execute([$title,$content,$nowTs,$id]);
+  $outline=mindmap_outline_preview($content);
+  $pdo->prepare('UPDATE mindmaps SET title=?, content=?, outline=?, updated_at=? WHERE id=?')
+      ->execute([$title,$content,$outline,$nowTs,$id]);
   return ['id'=>$id,'updated_at'=>$nowTs];
 }
 
@@ -3921,6 +3970,13 @@ if ($view === 'map_edit') {
       .mind-info-row .map-title-input{flex:1;min-width:0}
       .map-meta{display:flex;flex-wrap:wrap;gap:10px;align-items:center;font:600 11px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--text-muted)}
       .map-meta span{white-space:nowrap}
+      .export-settings{margin-top:14px;display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:14px;padding:16px;border-radius:18px;background:linear-gradient(140deg,rgba(15,19,22,.9),rgba(10,12,14,.9));border:1px solid rgba(201,168,106,.28);box-shadow:0 12px 32px rgba(0,0,0,.45)}
+      .export-setting{display:flex;flex-direction:column;gap:6px}
+      .export-setting label{font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase;color:var(--text-muted)}
+      .export-setting select,.export-setting input[type="number"]{padding:8px 12px;border-radius:12px;border:1px solid rgba(230,192,137,.32);background:rgba(15,19,22,.7);color:var(--text-strong);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;box-shadow:inset 0 0 18px rgba(201,168,106,.08);transition:border-color var(--transition),background var(--transition)}
+      .export-setting select:focus-visible,.export-setting input[type="number"]:focus-visible{outline:none;border-color:rgba(230,192,137,.6);box-shadow:0 0 0 3px rgba(230,192,137,.25)}
+      .export-setting input[type="range"]{accent-color:var(--gold-500);width:100%}
+      .export-setting--dpi{min-width:0}
       .map-delete-btn{margin-left:auto;padding:6px 12px;border-radius:12px;border:1px solid rgba(209,75,75,.52);background:rgba(209,75,75,.12);color:#F6D6D6;font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background var(--transition)}
       .map-delete-btn:hover{border-color:rgba(209,75,75,.72);background:rgba(209,75,75,.18)}
       .map-delete-btn:focus-visible{outline:3px solid rgba(209,75,75,.35);outline-offset:2px}
@@ -3942,6 +3998,7 @@ if ($view === 'map_edit') {
         .save-state{font-size:10px;padding:4px 10px}
         .map-meta{font-size:10px;gap:8px;letter-spacing:.12em;justify-content:space-between}
         .map-meta span{flex:1 1 auto;min-width:0}
+        .export-settings{grid-template-columns:repeat(1,minmax(0,1fr));padding:12px;margin-top:10px}
       }
       .mind-stage{position:relative;flex:1 1 auto;min-height:0;border-radius:28px;border:1px solid rgba(201,168,106,.24);background:linear-gradient(160deg,rgba(15,19,22,.9),rgba(10,12,14,.94));box-shadow:inset 0 0 48px rgba(0,0,0,.6),0 18px 38px rgba(0,0,0,.45);overflow:hidden}
       .mind-stage::before{content:"";position:absolute;inset:14px;border-radius:20px;border:1px dashed rgba(201,168,106,.2);opacity:.4;pointer-events:none}
@@ -4214,6 +4271,37 @@ if ($view === 'map_edit') {
               <?php if ($mind['id']): ?>
               <button type="button" class="map-delete-btn" id="map-delete-btn">删除导图</button>
               <?php endif; ?>
+            </div>
+            <div class="export-settings" id="export-settings" aria-label="导出质量设置">
+              <div class="export-setting">
+                <label for="export-resolution">导出分辨率</label>
+                <select id="export-resolution">
+                  <option value="2">2× 高清（默认）</option>
+                  <option value="1">1× 标准</option>
+                  <option value="device">跟随屏幕</option>
+                  <option value="3">3× 超清</option>
+                  <option value="4">4× 专业</option>
+                  <option value="6">6× 海报</option>
+                  <option value="custom-dpi">自定义 DPI</option>
+                </select>
+              </div>
+              <div class="export-setting export-setting--dpi" id="export-dpi-group" hidden>
+                <label for="export-dpi">目标 DPI</label>
+                <input id="export-dpi" type="number" min="72" max="600" step="12" value="240">
+              </div>
+              <div class="export-setting">
+                <label for="export-jpg-quality">JPG 质量 <span id="export-jpg-quality-value">90%</span></label>
+                <input id="export-jpg-quality" type="range" min="70" max="100" step="5" value="90">
+              </div>
+              <div class="export-setting">
+                <label for="export-pdf-compression">PDF 压缩</label>
+                <select id="export-pdf-compression">
+                  <option value="FAST">快速（文件较小）</option>
+                  <option value="MEDIUM">平衡</option>
+                  <option value="SLOW">高质量</option>
+                  <option value="NONE">无压缩</option>
+                </select>
+              </div>
             </div>
           </div>
         </header>
@@ -7949,6 +8037,13 @@ if ($view === 'map_edit') {
       const mapIo=document.getElementById('map-io');
       const mapIoButton=document.getElementById('map-io-button');
       const mapIoMenu=document.getElementById('map-io-menu');
+      const exportSettingsPanel=document.getElementById('export-settings');
+      const exportResolutionSelect=document.getElementById('export-resolution');
+      const exportDpiGroup=document.getElementById('export-dpi-group');
+      const exportDpiInput=document.getElementById('export-dpi');
+      const exportJpgQuality=document.getElementById('export-jpg-quality');
+      const exportJpgQualityValue=document.getElementById('export-jpg-quality-value');
+      const exportPdfCompression=document.getElementById('export-pdf-compression');
       const mapDeleteButton=document.getElementById('map-delete-btn');
       const importModal=document.getElementById('mind-import-modal');
       const importModalName=importModal ? importModal.querySelector('[data-import-name]') : null;
@@ -8027,6 +8122,74 @@ if ($view === 'map_edit') {
           exportOverlay.setAttribute('aria-hidden','true');
           exportOverlayHideTimer=null;
         },360);
+      }
+      function clampDpiValue(value){
+        const parsed=parseInt(value,10);
+        if(Number.isNaN(parsed)){ return 240; }
+        return Math.min(600, Math.max(72, parsed));
+      }
+      function resolveRequestedPixelRatio(){
+        if(!exportResolutionSelect){ return 2; }
+        const mode=exportResolutionSelect.value;
+        if(mode==='device'){ return Math.max(1, window.devicePixelRatio || 1); }
+        if(mode==='custom-dpi'){
+          const dpi=clampDpiValue(exportDpiInput ? exportDpiInput.value : 240);
+          return dpi / 96;
+        }
+        const numeric=parseFloat(mode);
+        return Number.isFinite(numeric) && numeric>0 ? numeric : 2;
+      }
+      function resolveEffectivePixelRatio(width,height){
+        const SAFE_CANVAS_BOUND=16384;
+        const requested=resolveRequestedPixelRatio();
+        const limit=Math.max(1, Math.floor(SAFE_CANVAS_BOUND / Math.max(width, height)));
+        return Math.max(1, Math.min(requested, limit));
+      }
+      function resolveTargetDpi(pixelRatio){
+        const effective=Math.round(Math.max(pixelRatio,1) * 96);
+        if(exportResolutionSelect && exportResolutionSelect.value==='custom-dpi'){
+          const requested=clampDpiValue(exportDpiInput ? exportDpiInput.value : 240);
+          return Math.min(requested, effective);
+        }
+        return effective;
+      }
+      function resolveJpgQuality(){
+        if(!exportJpgQuality){ return 0.95; }
+        const value=parseInt(exportJpgQuality.value,10);
+        if(Number.isNaN(value)){ return 0.9; }
+        return Math.min(1, Math.max(0.5, value/100));
+      }
+      function resolvePdfCompressionMode(){
+        const allowed=new Set(['FAST','MEDIUM','SLOW','NONE']);
+        const value=(exportPdfCompression ? String(exportPdfCompression.value).toUpperCase() : 'FAST');
+        return allowed.has(value)?value:'FAST';
+      }
+      function applyResolutionUiState(){
+        if(!exportResolutionSelect || !exportDpiGroup) return;
+        const shouldShow=exportResolutionSelect.value==='custom-dpi';
+        exportDpiGroup.hidden=!shouldShow;
+      }
+      function updateJpgQualityLabel(){
+        if(!exportJpgQuality || !exportJpgQualityValue) return;
+        const value=parseInt(exportJpgQuality.value,10);
+        const display=Number.isNaN(value)?'90%':`${value}%`;
+        exportJpgQualityValue.textContent=display;
+      }
+      if(exportResolutionSelect){
+        exportResolutionSelect.addEventListener('change',()=>{
+          applyResolutionUiState();
+        });
+        applyResolutionUiState();
+      }
+      if(exportDpiInput){
+        const clampInput=()=>{ exportDpiInput.value=String(clampDpiValue(exportDpiInput.value)); };
+        exportDpiInput.addEventListener('blur',clampInput);
+        exportDpiInput.addEventListener('change',clampInput);
+      }
+      if(exportJpgQuality){
+        exportJpgQuality.addEventListener('input',updateJpgQualityLabel);
+        exportJpgQuality.addEventListener('change',updateJpgQualityLabel);
+        updateJpgQualityLabel();
       }
       const UNDO_MAX_DEPTH=100;
       const UNDO_MERGE_WINDOW=200;
@@ -10744,12 +10907,10 @@ if ($view === 'map_edit') {
           }
           const viewportWidth=Math.max(1, Math.ceil(bounds.width));
           const viewportHeight=Math.max(1, Math.ceil(bounds.height));
-          const SAFE_CANVAS_BOUND=16384;
-          const basePixelRatio=window.devicePixelRatio || 1;
-          const minPixelRatio=2;
-          const maxPixelRatio=4;
-          const sizeLimitedRatio=Math.max(1, Math.floor(SAFE_CANVAS_BOUND / Math.max(viewportWidth, viewportHeight)));
-          const pixelRatio=Math.min(maxPixelRatio, Math.max(minPixelRatio, basePixelRatio), sizeLimitedRatio);
+          const pixelRatio=resolveEffectivePixelRatio(viewportWidth, viewportHeight);
+          const targetDpi=resolveTargetDpi(pixelRatio);
+          const jpgQuality=resolveJpgQuality();
+          const pdfCompression=resolvePdfCompressionMode();
           exportHost=document.createElement('div');
           exportHost.style.position='fixed';
           exportHost.style.left='-120vw';
@@ -10808,7 +10969,7 @@ if ($view === 'map_edit') {
           });
           if(!canvas){ throw new Error('无法生成导出图像'); }
           if(format==='jpg'){
-            const blob=await canvasToBlob(canvas,'image/jpeg',0.95);
+            const blob=await canvasToBlob(canvas,'image/jpeg',jpgQuality);
             const url=URL.createObjectURL(blob);
             const a=document.createElement('a');
             a.href=url;
@@ -10820,12 +10981,14 @@ if ($view === 'map_edit') {
           }else if(format==='pdf'){
             const jsPDF=await ensureJsPDF();
             const isLandscape=canvas.width>=canvas.height;
-            const pageSize=isLandscape?[canvas.height, canvas.width]:[canvas.width, canvas.height];
-            const pdf=new jsPDF({orientation:isLandscape?'landscape':'portrait', unit:'px', format:pageSize});
+            const pageWidthPt=(canvas.width/targetDpi)*72;
+            const pageHeightPt=(canvas.height/targetDpi)*72;
+            const pageSize=isLandscape?[pageHeightPt,pageWidthPt]:[pageWidthPt,pageHeightPt];
+            const pdf=new jsPDF({orientation:isLandscape?'landscape':'portrait', unit:'pt', format:pageSize});
             const dataUrl=canvas.toDataURL('image/png');
             const pageWidth=pdf.internal.pageSize.getWidth();
             const pageHeight=pdf.internal.pageSize.getHeight();
-            pdf.addImage(dataUrl,'PNG',0,0,pageWidth,pageHeight,undefined,'FAST');
+            pdf.addImage(dataUrl,'PNG',0,0,pageWidth,pageHeight,undefined,pdfCompression);
             pdf.save(buildExportFilename('pdf', titleValue));
           }else{
             throw new Error('不支持的导出格式');
@@ -11043,10 +11206,20 @@ $mindmap_total = (int)($stats['mindmap_total'] ?? 0);
 $isMindmapCategory = $cat === 'mindmaps';
 $items=[];
 $mindmapsAll=[];
+$stepsTimelineByItem=[];
+$itemAttachments=[];
+$pagination=['page'=>1,'per_page'=>30,'total'=>0,'pages'=>1];
 if($isMindmapCategory){
   $mindmapsAll=get_mindmaps();
   foreach($mindmapsAll as &$map){
-    $map['outline']=mindmap_outline_preview($map['content']);
+    $outline=(string)($map['outline'] ?? '');
+    if($outline===''){
+      $outline=mindmap_outline_preview((string)$map['content']);
+      $map['outline']=$outline;
+      $pdo->prepare('UPDATE mindmaps SET outline=? WHERE id=?')->execute([$outline,(int)$map['id']]);
+    }else{
+      $map['outline']=$outline;
+    }
   }
   unset($map);
 } else {
@@ -11056,14 +11229,53 @@ if($isMindmapCategory){
   }
   if($cat!=='all' && ctype_digit((string)$cat)){ $where[]='category_id = :cat'; $params[':cat']=(int)$cat; }
   if($q!==''){ $where[]='(title LIKE :q OR description LIKE :q)'; $params[':q']='%'.$q.'%'; }
-  $sql='SELECT * FROM items';
-  if($where) $sql.=' WHERE '.implode(' AND ',$where);
-  $sql.=' ORDER BY order_index ASC, updated_at DESC, id DESC';
-  $st=$pdo->prepare($sql); $st->execute($params); $items=$st->fetchAll();
+  $baseSql='FROM items';
+  if($where){
+    $baseSql.=' WHERE '.implode(' AND ', $where);
+  }
+  $countStmt=$pdo->prepare('SELECT COUNT(*) '.$baseSql);
+  foreach($params as $key=>$value){
+    $countStmt->bindValue($key,$value,is_int($value)?PDO::PARAM_INT:PDO::PARAM_STR);
+  }
+  $countStmt->execute();
+  $totalItems=(int)$countStmt->fetchColumn();
+  $perPage=30;
+  $pageRaw=$_GET['page'] ?? '1';
+  $page=ctype_digit((string)$pageRaw)?(int)$pageRaw:1;
+  if($page<1){ $page=1; }
+  $maxPage=$totalItems>0?(int)ceil($totalItems/$perPage):1;
+  if($maxPage<1){ $maxPage=1; }
+  if($page>$maxPage){ $page=$maxPage; }
+  $offset=($page-1)*$perPage;
+  if($offset<0){ $offset=0; }
+  $pagination=['page'=>$page,'per_page'=>$perPage,'total'=>$totalItems,'pages'=>$maxPage];
+  $sql='SELECT id,title,description,done,category_id,order_index,created_at,updated_at '.$baseSql.' ORDER BY order_index ASC, updated_at DESC, id DESC LIMIT :limit OFFSET :offset';
+  $st=$pdo->prepare($sql);
+  foreach($params as $key=>$value){
+    $st->bindValue($key,$value,is_int($value)?PDO::PARAM_INT:PDO::PARAM_STR);
+  }
+  $st->bindValue(':limit',$perPage,PDO::PARAM_INT);
+  $st->bindValue(':offset',$offset,PDO::PARAM_INT);
+  $st->execute();
+  $items=$st->fetchAll();
+  $itemIds=array_map(fn($row)=>(int)$row['id'],$items);
+  if($itemIds){
+    $stepsTimelineByItem=get_steps_by_time_grouped($itemIds);
+    $itemAttachments=attachments_for_items($itemIds);
+  }
 }
 $all_total = (int)($stats['active_total'] ?? 0);
 $categoryNames=[];
 foreach($cats as $c){ $categoryNames[(int)$c['id']]=$c['name']; }
+$pageQueryBase=['cat'=>$cat];
+if($q!==''){ $pageQueryBase['q']=$q; }
+$buildPageUrl=function(int $pageNum) use ($pageQueryBase){
+  $params=$pageQueryBase;
+  if($pageNum>1){ $params['page']=$pageNum; }
+  else{ unset($params['page']); }
+  $query=http_build_query($params);
+  return '?'.($query!==''?$query:'');
+};
 ?>
 <!doctype html>
 <html lang="zh-Hans">
@@ -11189,6 +11401,12 @@ foreach($cats as $c){ $categoryNames[(int)$c['id']]=$c['name']; }
   .density-toggle .btn.active{background:rgba(230,192,137,.16);color:var(--gold-400);box-shadow:inset 0 0 0 1px rgba(230,192,137,.25)}
   .items{display:grid;gap:var(--item-grid-gap);position:relative;grid-template-columns:repeat(3,minmax(0,1fr));align-items:start}
   .item{position:relative;padding:var(--item-padding);border-radius:var(--item-radius);background:linear-gradient(140deg,rgba(15,19,22,.9),rgba(10,12,14,.9));border:1px solid rgba(201,168,106,.28);box-shadow:var(--shadow);display:grid;gap:var(--item-gap);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),opacity var(--transition)}
+  .pager{margin-top:18px;padding:14px 18px;border-radius:16px;background:linear-gradient(140deg,rgba(15,19,22,.88),rgba(10,12,14,.88));border:1px solid rgba(201,168,106,.24);box-shadow:0 16px 36px rgba(0,0,0,.38);display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px}
+  .pager-info{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;color:var(--text-muted);text-transform:uppercase}
+  .pager-links{display:flex;gap:12px;flex-wrap:wrap}
+  .pager-link{display:inline-flex;align-items:center;justify-content:center;min-width:96px;padding:8px 16px;border-radius:12px;border:1px solid rgba(230,192,137,.32);background:rgba(15,19,22,.6);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase;text-decoration:none;transition:background var(--transition),border-color var(--transition),color var(--transition)}
+  .pager-link:hover{background:rgba(230,192,137,.14);border-color:rgba(230,192,137,.55);color:var(--gold-300,#f4d8a4)}
+  .pager-link.disabled{opacity:.45;pointer-events:none;cursor:default;border-color:rgba(230,192,137,.18);background:rgba(15,19,22,.45);color:var(--text-dim)}
   .item::before{content:"";position:absolute;inset:6px;border-radius:14px;border:1px dashed rgba(201,168,106,.28);opacity:.85;pointer-events:none;box-shadow:0 0 26px rgba(227,198,139,.18)}
   .item::after{content:"";position:absolute;top:14px;right:16px;width:11px;height:11px;border-radius:50%;background:var(--gold-500);box-shadow:0 0 12px rgba(207,166,107,.5),0 0 22px rgba(142,107,61,.45)}
   .item:hover{transform:translateY(-4px);box-shadow:0 0 28px rgba(201,168,106,.28),0 26px 50px rgba(0,0,0,.6);border-color:rgba(201,168,106,.52)}
@@ -11483,6 +11701,7 @@ foreach($cats as $c){ $categoryNames[(int)$c['id']]=$c['name']; }
         'id'=>$m['id'],
         'title'=>$m['title'],
         'content'=>$m['content'],
+        'outline'=>$m['outline'] ?? '',
         'created_at'=>$m['created_at'],
         'updated_at'=>$m['updated_at'],
       ], $mindmapsAll), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?></script>
@@ -11510,8 +11729,9 @@ foreach($cats as $c){ $categoryNames[(int)$c['id']]=$c['name']; }
         <?php endif; ?>
         <?php foreach ($items as $it): ?>
           <?php
-            $steps_time=get_steps_by_time((int)$it['id']);
-            $attachments=attachments_for_item((int)$it['id']);
+            $itemId=(int)$it['id'];
+            $steps_time=$stepsTimelineByItem[$itemId] ?? [];
+            $attachments=$itemAttachments[$itemId] ?? [];
             $titlePlain=(string)$it['title'];
             $titleHtml = $q!=='' ? highlight_text($titlePlain, $q) : h($titlePlain);
             $descRaw = (string)$it['description'];
@@ -11587,6 +11807,23 @@ foreach($cats as $c){ $categoryNames[(int)$c['id']]=$c['name']; }
         快捷键：<span class="kbd">/</span> 聚焦搜索。
       </div>
     <?php endif; ?>
+      <?php if ($pagination['pages'] > 1): ?>
+        <nav class="pager" aria-label="分页导航">
+          <div class="pager-info">第 <?= (int)$pagination['page']; ?> / <?= (int)$pagination['pages']; ?> 页 · 共 <?= (int)$pagination['total']; ?> 条</div>
+          <div class="pager-links">
+            <?php if ($pagination['page'] > 1): ?>
+              <a class="pager-link" href="<?= h($buildPageUrl($pagination['page'] - 1)); ?>" rel="prev">上一页</a>
+            <?php else: ?>
+              <span class="pager-link disabled" aria-disabled="true">上一页</span>
+            <?php endif; ?>
+            <?php if ($pagination['page'] < $pagination['pages']): ?>
+              <a class="pager-link" href="<?= h($buildPageUrl($pagination['page'] + 1)); ?>" rel="next">下一页</a>
+            <?php else: ?>
+              <span class="pager-link disabled" aria-disabled="true">下一页</span>
+            <?php endif; ?>
+          </div>
+        </nav>
+      <?php endif; ?>
   </main>
 </div>
 <div id="toast-container" class="toast-container" aria-live="assertive" aria-atomic="true"></div>


### PR DESCRIPTION
## 摘要
- 为 mindmaps 表新增 outline 列并在保存/初始化时填充缓存，避免重复解析
- 首页备忘录列表改为批量加载步骤与附件并加入分页与导航条
- 思维导图编辑页新增导出分辨率、JPG 质量与 PDF 压缩选项，提升导出清晰度

## 测试
- php -l memo.php
- php memo.php > /tmp/memo_cli_output.html

------
https://chatgpt.com/codex/tasks/task_e_68e666812b548328be8a13b69fa753bb