### PR TITLE
feat: 统一前端静态资源 CDN 引用

### DIFF
--- a/config/security.php
+++ b/config/security.php
@@ -14,11 +14,11 @@ return [
     'csp' => [
         'mode' => 'report-only',
         'directives' => [
-            'default-src' => "'self' cdn.jsdelivr.net",
+            'default-src' => "'self' fastly.jsdelivr.net",
             'img-src' => "'self' data: blob:",
-            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net fonts.googleapis.com",
-            'font-src' => "fonts.gstatic.com",
-            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
+            'style-src' => "'self' 'unsafe-inline' fastly.jsdelivr.net",
+            'font-src' => "fastly.jsdelivr.net",
+            'script-src' => "'self' 'unsafe-inline' fastly.jsdelivr.net",
             'base-uri' => "'self'",
             'form-action' => "'self'",
             'frame-ancestors' => "'self'",

--- a/memo.php
+++ b/memo.php
@@ -12,6 +12,7 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     session_start();
 }
 mb_internal_encoding('UTF-8');
+require __DIR__ . '/resources/views/memo/_cdn.php';
 
 // 移除默认 X-Powered-By 头
 header_remove('X-Powered-By');
@@ -21,7 +22,14 @@ header_remove('X-Powered-By');
 header('X-Frame-Options: SAMEORIGIN');
 header('Referrer-Policy: strict-origin-when-cross-origin');
 header('X-Content-Type-Options: nosniff');
-header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net fonts.googleapis.com; font-src fonts.gstatic.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
+$cspHeader = sprintf(
+    "Content-Security-Policy: default-src 'self' %s; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' %s; font-src %s; script-src 'self' 'unsafe-inline' %s; base-uri 'self'; form-action 'self'; frame-ancestors 'self'",
+    MEMO_CDN_HOST,
+    MEMO_CDN_HOST,
+    MEMO_CDN_HOST,
+    MEMO_CDN_HOST
+);
+header($cspHeader);
 
 // —— 配置 ——
 const DB_FILE = __DIR__ . '/memo.sqlite';

--- a/resources/views/memo/_cdn.php
+++ b/resources/views/memo/_cdn.php
@@ -1,0 +1,11 @@
+<?php
+if (!defined('MEMO_CDN_HOST')) {
+    $memoCdnHost = getenv('MEMO_CDN_HOST');
+    if (!$memoCdnHost) {
+        $memoCdnHost = 'https://fastly.jsdelivr.net';
+    }
+    $memoCdnHost = rtrim($memoCdnHost, '/');
+    define('MEMO_CDN_HOST', $memoCdnHost);
+    define('MEMO_CDN_NPM', MEMO_CDN_HOST . '/npm');
+    define('MEMO_CDN_COMBINE', MEMO_CDN_HOST . '/combine');
+}

--- a/resources/views/memo/index.phtml
+++ b/resources/views/memo/index.phtml
@@ -1,3 +1,4 @@
+<?php require __DIR__ . '/_cdn.php'; ?>
 <!doctype html>
 <html lang="zh-Hans">
 <head>
@@ -5,9 +6,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>自适应备忘录 · 单文件</title>
 <meta name="color-scheme" content="dark"/>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+<link rel="dns-prefetch" href="<?= MEMO_CDN_HOST ?>">
+<link rel="preconnect" href="<?= MEMO_CDN_HOST ?>" crossorigin>
+<link href="<?= MEMO_CDN_COMBINE ?>/npm/@fontsource/cinzel/index.css,npm/@fontsource/inter/index.css,npm/@fontsource/noto-sans-sc/index.css,npm/@fontsource/noto-serif-sc/index.css" rel="stylesheet" crossorigin>
 <style>
   :root{
     --bg-void:#0A0C0E;

--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -1,3 +1,4 @@
+  <?php require __DIR__ . '/_cdn.php'; ?>
   <!doctype html>
   <html lang="zh-Hans">
   <head>
@@ -5,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>详情 · <?php echo h($it['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="<?= MEMO_CDN_HOST ?>">
+    <link rel="preconnect" href="<?= MEMO_CDN_HOST ?>" crossorigin>
+    <link href="<?= MEMO_CDN_COMBINE ?>/npm/@fontsource/cinzel/index.css,npm/@fontsource/inter/index.css,npm/@fontsource/noto-sans-sc/index.css,npm/@fontsource/noto-serif-sc/index.css" rel="stylesheet" crossorigin>
     <style>
       :root{
         --bg-void:#0A0C0E;
@@ -372,8 +373,8 @@
         </div>
       </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script src="<?= MEMO_CDN_NPM ?>/marked/marked.min.js"></script>
+    <script src="<?= MEMO_CDN_NPM ?>/dompurify/dist/purify.min.js"></script>
     <script>
       (function(){
         if(window.AttachmentPreview) return;
@@ -702,7 +703,7 @@
           const attempt=async password=>{
             setLoadingMessage(password?'验证密码…':'解析压缩包…');
             const buffer=await loadBuffer(source);
-            await ensureScript('https://cdn.jsdelivr.net/npm/@zip.js/zip.js@2.7.32/dist/zip.min.js');
+            await ensureScript('<?= MEMO_CDN_NPM ?>/@zip.js/zip.js@2.7.32/dist/zip.min.js');
             const zipLib=window.zip;
             if(!zipLib || !zipLib.ZipReader || !zipLib.Uint8ArrayReader) throw new Error('解析库未加载');
             const reader=new zipLib.ZipReader(new zipLib.Uint8ArrayReader(new Uint8Array(buffer)), password?{password}:{});
@@ -748,7 +749,7 @@
           const attempt=async password=>{
             setLoadingMessage(password?'验证密码…':'解析压缩包…');
             const buffer=await loadBuffer(source);
-            await ensureScript('https://cdn.jsdelivr.net/npm/unrar-js@0.2.19/dist/unrar.js');
+            await ensureScript('<?= MEMO_CDN_NPM ?>/unrar-js@0.2.19/dist/unrar.js');
             const api=window.UNRAR || window.unrar;
             if(!api || typeof api.createExtractorFromData!=='function') throw new Error('解析库未加载');
             const extractor=await api.createExtractorFromData({data:buffer,password:password||undefined});
@@ -798,7 +799,7 @@
         const loadDocxPreview=async source=>{
           showLoading('解析文档…');
           const buffer=await loadBuffer(source);
-          await ensureScript('https://cdn.jsdelivr.net/npm/mammoth@1.6.0/mammoth.browser.min.js');
+          await ensureScript('<?= MEMO_CDN_NPM ?>/mammoth@1.6.0/mammoth.browser.min.js');
           if(!window.mammoth || typeof window.mammoth.convertToHtml!=='function') throw new Error('转换库未加载');
           const result=await window.mammoth.convertToHtml({arrayBuffer:buffer}).catch(err=>{ throw err; });
           const html=result && typeof result.value==='string' ? result.value : '';
@@ -811,7 +812,7 @@
         const loadExcelPreview=async source=>{
           showLoading('解析表格…');
           const buffer=await loadBuffer(source);
-          await ensureScript('https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js');
+          await ensureScript('<?= MEMO_CDN_NPM ?>/xlsx@0.18.5/dist/xlsx.full.min.js');
           if(!window.XLSX || typeof window.XLSX.read!=='function') throw new Error('解析库未加载');
           const workbook=window.XLSX.read(buffer,{type:'array'});
           const sheetNames=Array.isArray(workbook.SheetNames)?workbook.SheetNames:[];

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -1,3 +1,4 @@
+  <?php require __DIR__ . '/_cdn.php'; ?>
   <!doctype html>
   <html lang="zh-Hans">
   <head>
@@ -5,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>思维导图编辑器 · <?php echo h($mind['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="<?= MEMO_CDN_HOST ?>">
+    <link rel="preconnect" href="<?= MEMO_CDN_HOST ?>" crossorigin>
+    <link href="<?= MEMO_CDN_COMBINE ?>/npm/@fontsource/cinzel/index.css,npm/@fontsource/inter/index.css,npm/@fontsource/noto-sans-sc/index.css,npm/@fontsource/noto-serif-sc/index.css" rel="stylesheet" crossorigin>
     <style>
       :root{
         --bg-void:#0A0C0E;
@@ -930,7 +931,7 @@
           const attempt=async password=>{
             setLoadingMessage(password?'验证密码…':'解析压缩包…');
             const buffer=await loadBuffer(source);
-            await ensureScript('https://cdn.jsdelivr.net/npm/@zip.js/zip.js@2.7.32/dist/zip.min.js');
+            await ensureScript('<?= MEMO_CDN_NPM ?>/@zip.js/zip.js@2.7.32/dist/zip.min.js');
             const zipLib=window.zip;
             if(!zipLib || !zipLib.ZipReader || !zipLib.Uint8ArrayReader) throw new Error('解析库未加载');
             const reader=new zipLib.ZipReader(new zipLib.Uint8ArrayReader(new Uint8Array(buffer)), password?{password}:{});
@@ -976,7 +977,7 @@
           const attempt=async password=>{
             setLoadingMessage(password?'验证密码…':'解析压缩包…');
             const buffer=await loadBuffer(source);
-            await ensureScript('https://cdn.jsdelivr.net/npm/unrar-js@0.2.19/dist/unrar.js');
+            await ensureScript('<?= MEMO_CDN_NPM ?>/unrar-js@0.2.19/dist/unrar.js');
             const api=window.UNRAR || window.unrar;
             if(!api || typeof api.createExtractorFromData!=='function') throw new Error('解析库未加载');
             const extractor=await api.createExtractorFromData({data:buffer,password:password||undefined});
@@ -1026,7 +1027,7 @@
         const loadDocxPreview=async source=>{
           showLoading('解析文档…');
           const buffer=await loadBuffer(source);
-          await ensureScript('https://cdn.jsdelivr.net/npm/mammoth@1.6.0/mammoth.browser.min.js');
+          await ensureScript('<?= MEMO_CDN_NPM ?>/mammoth@1.6.0/mammoth.browser.min.js');
           if(!window.mammoth || typeof window.mammoth.convertToHtml!=='function') throw new Error('转换库未加载');
           const result=await window.mammoth.convertToHtml({arrayBuffer:buffer}).catch(err=>{ throw err; });
           const html=result && typeof result.value==='string' ? result.value : '';
@@ -1039,7 +1040,7 @@
         const loadExcelPreview=async source=>{
           showLoading('解析表格…');
           const buffer=await loadBuffer(source);
-          await ensureScript('https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js');
+          await ensureScript('<?= MEMO_CDN_NPM ?>/xlsx@0.18.5/dist/xlsx.full.min.js');
           if(!window.XLSX || typeof window.XLSX.read!=='function') throw new Error('解析库未加载');
           const workbook=window.XLSX.read(buffer,{type:'array'});
           const sheetNames=Array.isArray(workbook.SheetNames)?workbook.SheetNames:[];
@@ -3783,14 +3784,14 @@
       }
       async function ensureHtmlToImage(){
         if(window.htmlToImage){ return window.htmlToImage; }
-        const lib=await loadExternalScript('https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.min.js',()=>window.htmlToImage);
+        const lib=await loadExternalScript('<?= MEMO_CDN_NPM ?>/html-to-image@1.11.11/dist/html-to-image.min.js',()=>window.htmlToImage);
         if(lib){ return lib; }
         if(window.htmlToImage){ return window.htmlToImage; }
         throw new Error('图像导出依赖加载失败');
       }
       async function ensureJsPDF(){
         if(window.jspdf && window.jspdf.jsPDF){ return window.jspdf.jsPDF; }
-        const lib=await loadExternalScript('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',()=>window.jspdf);
+        const lib=await loadExternalScript('<?= MEMO_CDN_NPM ?>/jspdf@2.5.1/dist/jspdf.umd.min.js',()=>window.jspdf);
         if(lib && lib.jsPDF){ return lib.jsPDF; }
         if(window.jspdf && window.jspdf.jsPDF){ return window.jspdf.jsPDF; }
         throw new Error('PDF 导出依赖加载失败');

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -1,3 +1,4 @@
+  <?php require __DIR__ . '/_cdn.php'; ?>
   <!doctype html>
   <html lang="zh-Hans">
   <head>
@@ -5,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>新建备忘录</title>
     <meta name="color-scheme" content="dark"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+    <link rel="dns-prefetch" href="<?= MEMO_CDN_HOST ?>">
+    <link rel="preconnect" href="<?= MEMO_CDN_HOST ?>" crossorigin>
+    <link href="<?= MEMO_CDN_COMBINE ?>/npm/@fontsource/cinzel/index.css,npm/@fontsource/inter/index.css,npm/@fontsource/noto-sans-sc/index.css,npm/@fontsource/noto-serif-sc/index.css" rel="stylesheet" crossorigin>
     <style>
       :root{
         --bg-void:#0A0C0E;
@@ -184,8 +185,8 @@
         <div class="timeline" id="timeline" data-item="0"></div>
       </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script src="<?= MEMO_CDN_NPM ?>/marked/marked.min.js"></script>
+    <script src="<?= MEMO_CDN_NPM ?>/dompurify/dist/purify.min.js"></script>
     <script>
       (function(){
         if(window.AttachmentPreview) return;
@@ -514,7 +515,7 @@
           const attempt=async password=>{
             setLoadingMessage(password?'验证密码…':'解析压缩包…');
             const buffer=await loadBuffer(source);
-            await ensureScript('https://cdn.jsdelivr.net/npm/@zip.js/zip.js@2.7.32/dist/zip.min.js');
+            await ensureScript('<?= MEMO_CDN_NPM ?>/@zip.js/zip.js@2.7.32/dist/zip.min.js');
             const zipLib=window.zip;
             if(!zipLib || !zipLib.ZipReader || !zipLib.Uint8ArrayReader) throw new Error('解析库未加载');
             const reader=new zipLib.ZipReader(new zipLib.Uint8ArrayReader(new Uint8Array(buffer)), password?{password}:{});
@@ -560,7 +561,7 @@
           const attempt=async password=>{
             setLoadingMessage(password?'验证密码…':'解析压缩包…');
             const buffer=await loadBuffer(source);
-            await ensureScript('https://cdn.jsdelivr.net/npm/unrar-js@0.2.19/dist/unrar.js');
+            await ensureScript('<?= MEMO_CDN_NPM ?>/unrar-js@0.2.19/dist/unrar.js');
             const api=window.UNRAR || window.unrar;
             if(!api || typeof api.createExtractorFromData!=='function') throw new Error('解析库未加载');
             const extractor=await api.createExtractorFromData({data:buffer,password:password||undefined});
@@ -610,7 +611,7 @@
         const loadDocxPreview=async source=>{
           showLoading('解析文档…');
           const buffer=await loadBuffer(source);
-          await ensureScript('https://cdn.jsdelivr.net/npm/mammoth@1.6.0/mammoth.browser.min.js');
+          await ensureScript('<?= MEMO_CDN_NPM ?>/mammoth@1.6.0/mammoth.browser.min.js');
           if(!window.mammoth || typeof window.mammoth.convertToHtml!=='function') throw new Error('转换库未加载');
           const result=await window.mammoth.convertToHtml({arrayBuffer:buffer}).catch(err=>{ throw err; });
           const html=result && typeof result.value==='string' ? result.value : '';
@@ -623,7 +624,7 @@
         const loadExcelPreview=async source=>{
           showLoading('解析表格…');
           const buffer=await loadBuffer(source);
-          await ensureScript('https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js');
+          await ensureScript('<?= MEMO_CDN_NPM ?>/xlsx@0.18.5/dist/xlsx.full.min.js');
           if(!window.XLSX || typeof window.XLSX.read!=='function') throw new Error('解析库未加载');
           const workbook=window.XLSX.read(buffer,{type:'array'});
           const sheetNames=Array.isArray(workbook.SheetNames)?workbook.SheetNames:[];


### PR DESCRIPTION
## Summary
- 新增公共 CDN 引导脚本，统一配置外链资源的域名并支持环境变量覆盖
- 将所有前端模板中的字体与第三方脚本切换到统一的 fastly.jsdelivr.net CDN
- 更新 memo.php 及安全策略配置，确保 CSP 与新的外链域名保持一致

## Testing
- php -l memo.php config/security.php resources/views/memo/_cdn.php resources/views/memo/index.phtml resources/views/memo/item.phtml resources/views/memo/new.phtml resources/views/memo/map_edit.phtml

------
https://chatgpt.com/codex/tasks/task_e_68e6e27b6f348328875e4af5323669bd