### PR TITLE
使用 CDN 版本的前端依赖

### DIFF
--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -372,8 +372,8 @@
         </div>
       </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@11.2.0/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js"></script>
     <script>
       (function(){
         if(window.AttachmentPreview) return;

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -602,6 +602,7 @@
         </div>
       </div>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js"></script>
     <script>
       (function(){
         if(window.AttachmentPreview) return;

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -184,8 +184,8 @@
         <div class="timeline" id="timeline" data-item="0"></div>
       </div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@11.2.0/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js"></script>
     <script>
       (function(){
         if(window.AttachmentPreview) return;


### PR DESCRIPTION
## Summary
- 为新建与详情模板的 Marked 和 DOMPurify 引入固定版本的 jsDelivr CDN 链接
- 在思维导图编辑页添加 DOMPurify 的 CDN 引用以保障附件预览的安全渲染

## Testing
- php -l resources/views/memo/new.phtml
- php -l resources/views/memo/item.phtml
- php -l resources/views/memo/map_edit.phtml

------
https://chatgpt.com/codex/tasks/task_e_68e796256d1083289bb1c9b3e50edda5