### PR TITLE
Improve mindmap touch zoom and attachment persistence

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -464,6 +464,19 @@ function create_mindmap_asset(?int $map_id, ?string $node_uid, string $orig_name
   return get_mindmap_asset($id) ?? ['id'=>$id,'mindmap_id'=>$map_id,'node_uid'=>$node_uid,'session_key'=>$session_key,'orig_name'=>$orig_name,'stored_name'=>$stored_name,'mime'=>$mime,'size'=>$size,'created_at'=>now()];
 }
 
+function cleanup_stale_mindmap_session_assets(int $max_age_seconds = 172800, int $batch_limit = 200): void {
+  $max_age_seconds = max(60, $max_age_seconds);
+  $batch_limit = max(1, $batch_limit);
+  $threshold = now() - $max_age_seconds;
+  $pdo = db();
+  $st = $pdo->prepare("SELECT id FROM mindmap_assets WHERE (mindmap_id IS NULL OR mindmap_id=0) AND session_key IS NOT NULL AND session_key<>'' AND (created_at IS NULL OR created_at < ?) LIMIT ?");
+  $st->execute([$threshold, $batch_limit]);
+  foreach($st->fetchAll() as $row){
+    $assetId = isset($row['id']) ? (int)$row['id'] : 0;
+    if($assetId>0){ delete_mindmap_asset($assetId); }
+  }
+}
+
 function prune_mindmap_assets(int $map_id, array $keep_ids): void {
   $pdo=db();
   $ids=array_values(array_unique(array_map('intval',$keep_ids)));
@@ -800,6 +813,14 @@ if (isset($_GET['export'])) {
 }
 
 // —— 处理 POST 动作 ——
+{
+  $nowTs=now();
+  $lastGc=(int)($_SESSION['mindmap_asset_gc_at'] ?? 0);
+  if($nowTs-$lastGc>1800){
+    cleanup_stale_mindmap_session_assets();
+    $_SESSION['mindmap_asset_gc_at']=$nowTs;
+  }
+}
 if (is_post()) {
   $pdo=db(); $action=$_POST['action'] ?? '';
   try{

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -1547,36 +1547,35 @@
           if(!evt) return;
           const rect=this.container.getBoundingClientRect();
           if(!rect) return;
-          const trackpadThreshold=60;
-          const isTrackpadLike=evt.deltaMode===0 && Math.abs(evt.deltaY)<trackpadThreshold && Math.abs(evt.deltaX)<trackpadThreshold;
-          const wantsZoom=evt.ctrlKey || evt.metaKey || (!evt.shiftKey && !evt.altKey && !isTrackpadLike);
-          if(wantsZoom){
-            evt.preventDefault();
-            const baseScale=this.scale>0?this.scale:1;
-            const intensity=evt.deltaMode===1?0.12:(evt.deltaMode===2?0.35:0.0025);
-            const delta=evt.deltaY||0;
-            const nextScale=this.clampScale(baseScale*Math.exp(-delta*intensity), rect);
-            if(Math.abs(nextScale-baseScale)<0.0001) return;
-            const anchorX=evt.clientX-rect.left;
-            const anchorY=evt.clientY-rect.top;
-            const originX=(anchorX - this.offsetX)/baseScale;
-            const originY=(anchorY - this.offsetY)/baseScale;
-            this.scale=nextScale;
-            this.offsetX=anchorX - originX*this.scale;
-            this.offsetY=anchorY - originY*this.scale;
-            this.applyTransform();
+          evt.preventDefault();
+          const baseScale=this.scale>0?this.scale:1;
+          const pickDelta=(candidate, fallback)=>{
+            if(typeof candidate==='number' && !Number.isNaN(candidate) && candidate!==0){
+              return candidate;
+            }
+            return fallback;
+          };
+          let delta=pickDelta(evt.deltaY,0);
+          if(delta===0){
+            delta=pickDelta(evt.deltaX,0);
+          }
+          if(delta===0 && typeof evt.deltaZ==='number'){
+            delta=pickDelta(evt.deltaZ,0);
+          }
+          if(delta===0){
             return;
           }
-          evt.preventDefault();
-          let deltaX=evt.deltaX||0;
-          let deltaY=evt.deltaY||0;
-          if(evt.shiftKey && !evt.altKey){
-            deltaX+=deltaY;
-            deltaY=0;
-          }
-          const multiplier=evt.deltaMode===1?20:(evt.deltaMode===2?Math.max(rect.width,rect.height)*0.8:(isTrackpadLike?1:1.8));
-          this.offsetX-=deltaX*multiplier;
-          this.offsetY-=deltaY*multiplier;
+          const baseIntensity=evt.deltaMode===1?0.12:(evt.deltaMode===2?0.35:0.0025);
+          const intensity=(evt.ctrlKey || evt.metaKey)?baseIntensity*0.8:baseIntensity;
+          const nextScale=this.clampScale(baseScale*Math.exp(-delta*intensity), rect);
+          if(Math.abs(nextScale-baseScale)<0.0001) return;
+          const anchorX=evt.clientX-rect.left;
+          const anchorY=evt.clientY-rect.top;
+          const originX=(anchorX - this.offsetX)/baseScale;
+          const originY=(anchorY - this.offsetY)/baseScale;
+          this.scale=nextScale;
+          this.offsetX=anchorX - originX*this.scale;
+          this.offsetY=anchorY - originY*this.scale;
           this.applyTransform();
         }
         add_event_listener(fn){ if(typeof fn==='function'){ this.listeners.push(fn); } }
@@ -4557,6 +4556,41 @@
       const audioExts=['.mp3','.m4a','.aac','.wav','.ogg','.oga','.opus','.flac','.weba'];
       const officeExts=['.pdf','.doc','.docx','.docm','.dotx','.dotm','.xls','.xlsx','.xlsm','.xlsb','.xltx','.xltm'];
       const archiveExts=['.zip','.rar'];
+      const AUTO_SAVE_INITIAL_DELAY=800;
+      const AUTO_SAVE_MAX_DELAY=10000;
+      let autoSaveTimer=null;
+      let autoSaveBackoff=AUTO_SAVE_INITIAL_DELAY;
+      let saveInFlightPromise=null;
+      let saveInFlightMode='idle';
+      function cancelAutoSaveTimer(){
+        if(autoSaveTimer){
+          clearTimeout(autoSaveTimer);
+          autoSaveTimer=null;
+        }
+      }
+      async function runAutoSave(reason){
+        if(!dirty){
+          autoSaveBackoff=AUTO_SAVE_INITIAL_DELAY;
+          return;
+        }
+        const ok=await saveMindmap({silent:true});
+        if(!ok && dirty){
+          autoSaveBackoff=Math.min(autoSaveBackoff*2,AUTO_SAVE_MAX_DELAY);
+          scheduleAutoSave(reason,autoSaveBackoff);
+        }else{
+          autoSaveBackoff=AUTO_SAVE_INITIAL_DELAY;
+        }
+      }
+      function scheduleAutoSave(reason='auto', delay){
+        const wait=(typeof delay==='number' && delay>=0)?delay:autoSaveBackoff;
+        if(autoSaveTimer){
+          clearTimeout(autoSaveTimer);
+        }
+        autoSaveTimer=window.setTimeout(()=>{
+          autoSaveTimer=null;
+          runAutoSave(reason);
+        }, wait);
+      }
       function setSaveButtonState(text, disabled, state){
         if(dockSaveLabel){
           if(typeof text==='string'){ dockSaveLabel.textContent=text; }
@@ -5669,6 +5703,7 @@
         markDirty();
         scheduleHandleRefresh();
         refreshInspector(jm.get_node(targetNode.id));
+        scheduleAutoSave('attachment-upload');
         if(attachmentManager && uploadedEntries.length){ attachmentManager.onFilesUploaded(uploadedEntries, targetNode); }
       }
       function handleDroppedText(text, parent, event){
@@ -6362,7 +6397,7 @@
             setTimeout(()=>el.classList.remove('mind-node-highlight'),1000);
           }
         }
-        function handleDelete(ids){
+        async function handleDelete(ids){
           const unique=Array.from(new Set(ids.map(id=>Number(id)).filter(id=>Number.isFinite(id) && id>0)));
           if(!unique.length) return;
           let total=0;
@@ -6372,15 +6407,32 @@
           const changed=removeAttachmentsFromMind(unique);
           const metaBackup=backupAndRemoveAssetMeta(unique);
           refresh(true);
-          requestDelete(unique).then(()=>{
+          if(changed){
+            const saved=await saveMindmap({silent:true});
+            if(!saved){
+              alert('保存导图失败，附件暂未删除。');
+              restoreAssetMeta(metaBackup);
+              undoMindChange();
+              refresh(true);
+              return;
+            }
+          }
+          try{
+            await requestDelete(unique);
             state.selection.clear();
             refresh(true);
-          }).catch(err=>{
+          }catch(err){
             alert(err && err.message ? err.message : '删除附件失败');
             restoreAssetMeta(metaBackup);
-            if(changed){ undoMindChange(); }
-            refresh(true);
-          });
+            if(changed){
+              undoMindChange();
+              refresh(true);
+              const rollbackSaved=await saveMindmap({silent:true});
+              if(!rollbackSaved){ markDirty(); }
+            }else{
+              refresh(true);
+            }
+          }
         }
         function removeAttachmentsFromMind(ids){
           if(!ids || !ids.length) return false;
@@ -7211,38 +7263,74 @@
           reader.readAsText(file,'utf-8');
         });
       }
-      async function saveMindmap(){
-        commitInlineEditing();
-        const title=titleInput.value.trim()||'未命名导图';
-        const currentData=jm.get_data('node_tree');
-        if(currentData && currentData.data){ enforceRightOrientation(currentData.data); }
-        const payload=JSON.stringify(currentData);
-        const fd=new FormData();
-        fd.append('action','save_mindmap');
-        fd.append('id', String(currentMapId||0));
-        fd.append('title', title);
-        fd.append('content', payload);
-        try{
-          showSaving();
-          const res=await fetch(location.href,{method:'POST',body:fd,headers:{'X-Requested-With':'fetch'}});
-          if(!res.ok) throw new Error('网络异常');
-          const json=await res.json();
-          if(!json.ok) throw new Error(json.error||'保存失败');
-          currentMapId=parseInt(json.id,10)||0;
-          document.getElementById('jsmind-container').dataset.mapId=currentMapId;
-          if(mapDeleteButton){ mapDeleteButton.disabled=!currentMapId; }
-          if(deleteMapForm){
-            const idInput=deleteMapForm.querySelector('input[name="id"]');
-            if(idInput){ idInput.value=currentMapId ? String(currentMapId) : ''; }
+      async function saveMindmap(options={}){
+        const opts=(options && typeof options==='object')?options:{};
+        const silent=!!opts.silent;
+        if(saveInFlightPromise){
+          if(!silent && saveInFlightMode==='silent' && !opts.__afterWait){
+            try{ await saveInFlightPromise; }catch(_){ }
+            const retryOptions=Object.assign({}, opts, {__afterWait:true});
+            return saveMindmap(retryOptions);
           }
-          history.replaceState(null,'',`?view=map_edit&id=${json.id}`);
-          initialData=JSON.parse(payload);
-          if(initialData && initialData.data){ enforceRightOrientation(initialData.data); }
-          markSaved();
-        }catch(err){
-          alert(err.message||'保存失败');
-          markDirty();
+          return saveInFlightPromise;
         }
+        cancelAutoSaveTimer();
+        saveInFlightMode=silent?'silent':'interactive';
+        const execute=async()=>{
+          commitInlineEditing();
+          const title=titleInput.value.trim()||'未命名导图';
+          const currentData=jm.get_data('node_tree');
+          if(currentData && currentData.data){ enforceRightOrientation(currentData.data); }
+          const payload=JSON.stringify(currentData);
+          const fd=new FormData();
+          fd.append('action','save_mindmap');
+          fd.append('id', String(currentMapId||0));
+          fd.append('title', title);
+          fd.append('content', payload);
+          try{
+            if(!silent){ showSaving(); }
+            const res=await fetch(location.href,{method:'POST',body:fd,headers:{'X-Requested-With':'fetch'}});
+            if(!res.ok) throw new Error('网络异常');
+            const json=await res.json();
+            if(!json.ok) throw new Error(json.error||'保存失败');
+            currentMapId=parseInt(json.id,10)||0;
+            document.getElementById('jsmind-container').dataset.mapId=currentMapId;
+            if(mapDeleteButton){ mapDeleteButton.disabled=!currentMapId; }
+            if(deleteMapForm){
+              const idInput=deleteMapForm.querySelector('input[name="id"]');
+              if(idInput){ idInput.value=currentMapId ? String(currentMapId) : ''; }
+            }
+            history.replaceState(null,'',`?view=map_edit&id=${json.id}`);
+            initialData=JSON.parse(payload);
+            if(initialData && initialData.data){ enforceRightOrientation(initialData.data); }
+            markSaved();
+            autoSaveBackoff=AUTO_SAVE_INITIAL_DELAY;
+            return true;
+          }catch(err){
+            if(!silent){
+              alert(err.message||'保存失败');
+            }else{
+              console.error('自动保存失败', err);
+              if(saveState){
+                saveState.textContent='自动保存失败';
+                saveState.classList.add('show','dirty');
+              }
+              setSaveButtonState('未保存',false,'dirty');
+            }
+            markDirty();
+            return false;
+          }
+        };
+        const promise=(async()=>{
+          try{
+            return await execute();
+          }finally{
+            saveInFlightPromise=null;
+            saveInFlightMode='idle';
+          }
+        })();
+        saveInFlightPromise=promise;
+        return promise;
       }
       window.addEventListener('beforeunload',e=>{
         commitInlineEditing();


### PR DESCRIPTION
## Summary
- refine the mindmap wheel handler so the canvas always zooms around the cursor while panning stays on drag for clearer control
- add automatic mindmap saves after attachment uploads with save de-duplication and UI feedback to keep nodes and files in sync
- clean up stale session-based mindmap assets periodically to avoid orphaned uploads
- auto-save before deleting attachments and roll back both metadata and node changes when deletion fails to keep references consistent

## Testing
- `php -l memo.php`
- `php -l resources/views/memo/map_edit.phtml`


------
https://chatgpt.com/codex/tasks/task_e_68e79b0cfa008328b1ff470cddfb0fe3