### PR TITLE
优化思维导图的滚轮与触控板交互体验

### DIFF
--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -1311,6 +1311,9 @@
           this.boundPanKeyUp=null;
           this.boundPanBlur=null;
           this.isPointerPanning=false;
+          this.lastWheelEventTime=0;
+          this.lastWheelIntent=null;
+          this.panActivationThreshold=6;
           this.resizeObserver=typeof ResizeObserver!=='undefined'?new ResizeObserver(entries=>this.handleNodeResize(entries)):null;
           this.setupPan();
           this.setupTouchGuards();
@@ -1370,6 +1373,10 @@
         }
         setupPan(){
           this.ensurePanKeyHandlers();
+          const isInteractiveTarget=(target)=>{
+            if(!target || !target.closest) return false;
+            return !!target.closest('input,textarea,select,button,a[href],[contenteditable="true"],[role="button"],[role="textbox"]');
+          };
           const updatePinchBaseline=()=>{
             if(this.activePointers.size<2){ this.pinchState=null; return; }
             const pointers=Array.from(this.activePointers.values());
@@ -1393,6 +1400,7 @@
             this.clearEdgeHover();
             const isTouch=evt.pointerType==='touch';
             const onNode=!!(evt.target && evt.target.closest && evt.target.closest('.jsmind-node'));
+            const interactiveTarget=isInteractiveTarget(evt.target);
             if(isTouch){
               this.activePointers.set(evt.pointerId,{x:evt.clientX,y:evt.clientY});
               if(this.activePointers.size>=2){
@@ -1410,7 +1418,7 @@
                 return;
               }
               try{ this.container.setPointerCapture(evt.pointerId); }catch(_){ }
-              this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY};
+              this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY,active:true,onNode,interactive:false};
               this.updatePointerPanState(true);
               evt.preventDefault();
               return;
@@ -1419,12 +1427,24 @@
             const isPrimary=button===0;
             const isMiddle=button===1;
             if(!isPrimary && !isMiddle) return;
-            if(onNode && !(this.spacePanActive || isMiddle)) return;
+            if(interactiveTarget && !isMiddle) return;
             this.activePointers.set(evt.pointerId,{x:evt.clientX,y:evt.clientY});
-            try{ this.container.setPointerCapture(evt.pointerId); }catch(_){ }
-            this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY};
-            this.updatePointerPanState(true);
-            evt.preventDefault();
+            const activateImmediately=isMiddle || this.spacePanActive;
+            this.dragState={
+              pointerId:evt.pointerId,
+              startX:evt.clientX,
+              startY:evt.clientY,
+              baseX:this.offsetX,
+              baseY:this.offsetY,
+              active:activateImmediately,
+              onNode,
+              interactive:interactiveTarget
+            };
+            if(activateImmediately){
+              try{ this.container.setPointerCapture(evt.pointerId); }catch(_){ }
+              this.updatePointerPanState(true);
+              evt.preventDefault();
+            }
           };
           const movePan=(evt)=>{
             if(!this.activePointers.has(evt.pointerId)) return;
@@ -1453,13 +1473,28 @@
                 }
                 return;
               }
-              if(this.dragState && this.dragState.pointerId===evt.pointerId){
-                evt.preventDefault();
-              }
             }
             if(!this.dragState || evt.pointerId!==this.dragState.pointerId) return;
             const dx=evt.clientX-this.dragState.startX;
             const dy=evt.clientY-this.dragState.startY;
+            if(isTouch){
+              evt.preventDefault();
+            }
+            if(!this.dragState.active){
+              if(this.dragState.interactive && !this.spacePanActive){
+                return;
+              }
+              const threshold=Math.max(2, this.panActivationThreshold||0);
+              if(Math.hypot(dx, dy)<threshold){
+                return;
+              }
+              this.dragState.active=true;
+              try{ this.container.setPointerCapture(evt.pointerId); }catch(_){ }
+              this.updatePointerPanState(true);
+            }
+            if(!isTouch){
+              evt.preventDefault();
+            }
             this.offsetX=this.dragState.baseX+dx;
             this.offsetY=this.dragState.baseY+dy;
             this.applyTransform();
@@ -1469,8 +1504,9 @@
               this.activePointers.delete(evt.pointerId);
             }
             if(this.dragState && evt.pointerId===this.dragState.pointerId){
+              const wasActive=!!this.dragState.active;
               this.dragState=null;
-              this.updatePointerPanState(false);
+              if(wasActive){ this.updatePointerPanState(false); }
             }
             if(this.activePointers.size<2){
               this.pinchState=null;
@@ -1548,12 +1584,52 @@
           const rect=this.container.getBoundingClientRect();
           if(!rect) return;
           evt.preventDefault();
+          const deltaX=evt.deltaX||0;
+          const deltaY=evt.deltaY||0;
+          const deltaMode=typeof evt.deltaMode==='number'?evt.deltaMode:0;
+          const now=(typeof performance!=='undefined' && performance.now)?performance.now():Date.now();
+          const hasTouchSource=!!(evt.sourceCapabilities && evt.sourceCapabilities.firesTouchEvents);
+          const isPinchGesture=!!(evt.ctrlKey || (typeof evt.deltaZ==='number' && evt.deltaZ!==0));
+          const magnitude=Math.max(Math.abs(deltaX), Math.abs(deltaY));
+          const isFractional=(!Number.isInteger(deltaX) || !Number.isInteger(deltaY));
+          const elapsed=now-(this.lastWheelEventTime||0);
+          let treatAsPan=false;
+          if(!isPinchGesture){
+            if(hasTouchSource){
+              treatAsPan=true;
+            }else if(deltaMode===0){
+              if((magnitude>0 && magnitude<=80) || isFractional || (this.lastWheelIntent==='pan' && elapsed<80)){
+                treatAsPan=true;
+              }
+            }
+          }
+          this.lastWheelEventTime=now;
+          if(treatAsPan){
+            this.lastWheelIntent='pan';
+            const unit=deltaMode===1?40:(deltaMode===2?rect.height:1);
+            const panX=deltaX*unit;
+            const panY=deltaY*unit;
+            if(Math.abs(panX)>0.0001 || Math.abs(panY)>0.0001){
+              this.offsetX-=panX;
+              this.offsetY-=panY;
+              this.applyTransform();
+            }
+            return;
+          }
+          this.lastWheelIntent='zoom';
           const baseScale=this.scale>0?this.scale:1;
-          const dominantDelta=(Math.abs(evt.deltaY||0)>=Math.abs(evt.deltaX||0))? (evt.deltaY||0) : (evt.deltaX||0);
-          const delta=dominantDelta!==0?dominantDelta:((typeof evt.deltaZ==='number' && evt.deltaZ!==0)?evt.deltaZ:evt.deltaY||0);
-          if(delta===0) return;
-          const intensity=evt.deltaMode===1?0.12:(evt.deltaMode===2?0.35:0.0025);
-          const nextScale=this.clampScale(baseScale*Math.exp(-delta*intensity), rect);
+          let dominantDelta=(Math.abs(deltaY)>=Math.abs(deltaX))? deltaY : deltaX;
+          if(dominantDelta===0 && typeof evt.deltaZ==='number' && evt.deltaZ!==0){
+            dominantDelta=evt.deltaZ;
+          }
+          if(dominantDelta===0) return;
+          let intensity;
+          if(isPinchGesture && deltaMode===0){
+            intensity=0.0035;
+          }else{
+            intensity=deltaMode===1?0.12:(deltaMode===2?0.35:0.0025);
+          }
+          const nextScale=this.clampScale(baseScale*Math.exp(-dominantDelta*intensity), rect);
           if(Math.abs(nextScale-baseScale)<0.0001) return;
           const anchorX=evt.clientX-rect.left;
           const anchorY=evt.clientY-rect.top;


### PR DESCRIPTION
## Summary
- 为思维导图容器增加轮滚交互状态记录，区分鼠标滚轮缩放与触控板双指平移/捏合
- 调整拖拽平移的判定逻辑，允许左键拖拽触发平移并对交互元素做保护，避免误触

## Testing
- npm test *(fails: package.json 不存在，无法执行)*
- npm run lint *(fails: package.json 不存在，无法执行)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a9db90648328af50c8b82c947b24