### PR TITLE
Support trackpad pan and pinch gestures

### DIFF
--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -1298,6 +1298,8 @@
             document.body.appendChild(this.measureHost);
           }
           this.dragState=null;
+          this.panSuppressClick=false;
+          this.panSuppressTimeout=null;
           this.activePointers=new Map();
           this.pinchState=null;
           this.relations=[];
@@ -1314,6 +1316,23 @@
           this.resizeObserver=typeof ResizeObserver!=='undefined'?new ResizeObserver(entries=>this.handleNodeResize(entries)):null;
           this.setupPan();
           this.setupTouchGuards();
+        }
+        resetPanClickSuppression(){
+          if(this.panSuppressTimeout){
+            clearTimeout(this.panSuppressTimeout);
+            this.panSuppressTimeout=null;
+          }
+          this.panSuppressClick=false;
+        }
+        suppressClickAfterPan(){
+          this.panSuppressClick=true;
+          if(this.panSuppressTimeout){
+            clearTimeout(this.panSuppressTimeout);
+          }
+          this.panSuppressTimeout=setTimeout(()=>{
+            this.panSuppressClick=false;
+            this.panSuppressTimeout=null;
+          },120);
         }
         ensurePanKeyHandlers(){
           if(this.globalPanKeyHandlersAttached) return;
@@ -1410,7 +1429,8 @@
                 return;
               }
               try{ this.container.setPointerCapture(evt.pointerId); }catch(_){ }
-              this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY};
+              this.resetPanClickSuppression();
+              this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY,moved:false};
               this.updatePointerPanState(true);
               evt.preventDefault();
               return;
@@ -1422,7 +1442,8 @@
             if(onNode && !(this.spacePanActive || isMiddle)) return;
             this.activePointers.set(evt.pointerId,{x:evt.clientX,y:evt.clientY});
             try{ this.container.setPointerCapture(evt.pointerId); }catch(_){ }
-            this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY};
+            this.resetPanClickSuppression();
+            this.dragState={pointerId:evt.pointerId,startX:evt.clientX,startY:evt.clientY,baseX:this.offsetX,baseY:this.offsetY,moved:false};
             this.updatePointerPanState(true);
             evt.preventDefault();
           };
@@ -1460,6 +1481,10 @@
             if(!this.dragState || evt.pointerId!==this.dragState.pointerId) return;
             const dx=evt.clientX-this.dragState.startX;
             const dy=evt.clientY-this.dragState.startY;
+            if(!this.dragState.moved){
+              const movement=Math.max(Math.abs(dx), Math.abs(dy));
+              if(movement>2){ this.dragState.moved=true; }
+            }
             this.offsetX=this.dragState.baseX+dx;
             this.offsetY=this.dragState.baseY+dy;
             this.applyTransform();
@@ -1468,7 +1493,9 @@
             if(this.activePointers.has(evt.pointerId)){
               this.activePointers.delete(evt.pointerId);
             }
-            if(this.dragState && evt.pointerId===this.dragState.pointerId){
+            const wasDrag=this.dragState && evt.pointerId===this.dragState.pointerId;
+            const moved=wasDrag && this.dragState.moved;
+            if(wasDrag){
               this.dragState=null;
               this.updatePointerPanState(false);
             }
@@ -1477,6 +1504,7 @@
             }else{
               updatePinchBaseline();
             }
+            if(moved){ this.suppressClickAfterPan(); }
             try{ this.container.releasePointerCapture(evt.pointerId); }catch(_){ }
           };
           this.container.addEventListener('pointerdown',startPan);
@@ -1549,8 +1577,20 @@
           if(!rect) return;
           evt.preventDefault();
           const baseScale=this.scale>0?this.scale:1;
-          const dominantDelta=(Math.abs(evt.deltaY||0)>=Math.abs(evt.deltaX||0))? (evt.deltaY||0) : (evt.deltaX||0);
-          const delta=dominantDelta!==0?dominantDelta:((typeof evt.deltaZ==='number' && evt.deltaZ!==0)?evt.deltaZ:evt.deltaY||0);
+          const absDeltaX=Math.abs(evt.deltaX||0);
+          const absDeltaY=Math.abs(evt.deltaY||0);
+          const deltaZ=typeof evt.deltaZ==='number'?evt.deltaZ:0;
+          const isPinchGesture=evt.ctrlKey || evt.metaKey || Math.abs(deltaZ)>0.0001;
+          const isTrackpadScroll=!isPinchGesture && evt.deltaMode===0 && (absDeltaX>0 || absDeltaY>0) && absDeltaX<120 && absDeltaY<120;
+          if(isTrackpadScroll){
+            const panFactor=evt.deltaMode===1?18:(evt.deltaMode===2?240:1);
+            this.offsetX-=evt.deltaX*panFactor;
+            this.offsetY-=evt.deltaY*panFactor;
+            this.applyTransform();
+            return;
+          }
+          const dominantDelta=(absDeltaY>=absDeltaX)? (evt.deltaY||0) : (evt.deltaX||0);
+          const delta=dominantDelta!==0?dominantDelta:(deltaZ!==0?deltaZ:(evt.deltaY||0));
           if(delta===0) return;
           const intensity=evt.deltaMode===1?0.12:(evt.deltaMode===2?0.35:0.0025);
           const nextScale=this.clampScale(baseScale*Math.exp(-delta*intensity), rect);
@@ -2334,6 +2374,11 @@
           }
           if(!forMeasure){
             el.addEventListener('click',(evt)=>{
+              if(this.isPointerPanning || this.panSuppressClick){
+                evt.preventDefault();
+                evt.stopPropagation();
+                return;
+              }
               const wasSelected=!!node.selected;
               this.select_node(node.id);
               if(isCompactViewport()){


### PR DESCRIPTION
## Summary
- detect trackpad pinch gestures via modifier state and deltaZ to continue scaling behaviour
- treat smooth two-finger scrolls as canvas pans so touchpad users can reposition the mind map naturally

## Testing
- php -l resources/views/memo/map_edit.phtml
- composer test *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_68e7d863399c83289224c94dc5b2ed32