### PR TITLE
refactor: share memo styles and assets

### DIFF
--- a/public/assets/css/common.css
+++ b/public/assets/css/common.css
@@ -1,0 +1,575 @@
+/* Shared memo experience styles */
+:root {
+  color-scheme: dark;
+  --bg-void: #0A0C0E;
+  --bg-elev-1: #0F1316;
+  --bg-elev-2: #151A1E;
+  --gold-700: #AA8C54;
+  --gold-600: #C9A86A;
+  --gold-500: #D1B274;
+  --gold-400: #E3C68B;
+  --accent-emerald: #24C2A0;
+  --accent-crimson: #D14B4B;
+  --accent-cyan: #4BC3D1;
+  --text-strong: #E8E5DF;
+  --text-muted: #7A766E;
+  --text-dim: #A7A39A;
+  --divider: rgba(201,168,106,0.18);
+  --panel: rgba(21,26,30,0.92);
+  --panel-strong: rgba(15,19,22,0.95);
+  --glow: var(--gold-500);
+  --glow-soft: rgba(227,198,139,0.26);
+  --glow-strong: rgba(227,198,139,0.40);
+  --border: rgba(201,168,106,0.38);
+  --border-soft: rgba(201,168,106,0.18);
+  --danger: var(--accent-crimson);
+  --danger-soft: rgba(209,75,75,0.32);
+  --grid-size: 72px;
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.72);
+  --transition: 300ms cubic-bezier(.22,.61,.36,1);
+  --font-sans: 'Noto Sans SC', 'Source Han Sans SC', 'Inter', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  --font-heading: 'Cinzel', 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC', serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+@font-face {
+  font-family: 'Cinzel';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local('Cinzel SemiBold'), local('Cinzel-SemiBold');
+}
+
+@font-face {
+  font-family: 'Cinzel';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: local('Cinzel Bold'), local('Cinzel-Bold');
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Inter'), local('Inter-Regular');
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local('Inter SemiBold'), local('Inter-SemiBold');
+}
+
+@font-face {
+  font-family: 'Noto Sans SC';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: local('Noto Sans SC Regular'), local('Source Han Sans SC Normal'), local('Microsoft YaHei');
+}
+
+@font-face {
+  font-family: 'Noto Sans SC';
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+  src: local('Noto Sans SC Medium'), local('Source Han Sans SC Medium'), local('PingFang SC Semibold');
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-void);
+  color: var(--text-strong);
+  font: 16px/1.65 var(--font-sans);
+  letter-spacing: 0.01em;
+  position: relative;
+  overflow-x: hidden;
+}
+
+body {
+  background:
+    radial-gradient(1200px 700px at 70% -10%, rgba(227,198,139,0.06), transparent 60%),
+    linear-gradient(120deg, rgba(201,168,106,0.08), transparent 30%, rgba(201,168,106,0.06) 70%, transparent 90%),
+    var(--bg-void);
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(10,12,14,0.45), rgba(10,12,14,0.82)),
+    url('/assets/img/golden-grid.svg');
+  background-size: cover, 160px 160px;
+  opacity: 0.58;
+  pointer-events: none;
+  z-index: -3;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(1200px 700px at 70% -10%, rgba(227,198,139,0.06), transparent 60%),
+    linear-gradient(120deg, rgba(201,168,106,0.08), transparent 30%, rgba(201,168,106,0.06) 70%, transparent 90%),
+    repeating-linear-gradient(0deg, rgba(75,195,209,0.08) 0, rgba(75,195,209,0.08) 1px, transparent 1px, transparent var(--grid-size)),
+    repeating-linear-gradient(90deg, rgba(201,168,106,0.12) 0, rgba(201,168,106,0.12) 1px, transparent 1px, transparent var(--grid-size));
+  mix-blend-mode: screen;
+  opacity: 0.32;
+  pointer-events: none;
+  z-index: -4;
+  background-size: 100% 100%, 100% 100%, var(--grid-size) var(--grid-size), var(--grid-size) var(--grid-size);
+  background-attachment: fixed;
+}
+
+.scanlines {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background: linear-gradient(to bottom, rgba(75,195,209,0.14) 0, transparent 4px);
+  background-size: 100% 6px;
+  opacity: 0.18;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.btn,
+.button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-strong);
+  font: 600 12px/1 var(--font-sans);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: none;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+  cursor: pointer;
+}
+
+.btn::before,
+.button::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 1px rgba(227,198,139,0.08);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.btn:hover::before,
+.button:hover::before {
+  opacity: 1;
+}
+
+.btn:focus-visible,
+.button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(230,192,137,0.5);
+}
+
+.btn:active,
+.button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.btn-primary,
+.btn.acc {
+  background: linear-gradient(135deg, var(--gold-500), var(--gold-600));
+  color: #1b1306;
+  border-color: rgba(142,107,61,0.75);
+  box-shadow: 0 16px 34px rgba(227,198,139,0.24), 0 0 24px rgba(227,198,139,0.18);
+}
+
+.btn-primary:hover,
+.btn.acc:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px rgba(227,198,139,0.3), 0 0 30px rgba(227,198,139,0.24);
+}
+
+.btn-outline {
+  border: 1px solid rgba(230,192,137,0.4);
+  background: rgba(15,19,22,0.6);
+  color: var(--gold-500);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.32);
+}
+
+.btn-outline:hover {
+  border-color: rgba(230,192,137,0.65);
+  color: var(--gold-400);
+}
+
+.btn-ghost {
+  border: 1px solid rgba(230,192,137,0.25);
+  background: transparent;
+  color: var(--gold-500);
+}
+
+.btn-ghost:hover {
+  background: rgba(230,192,137,0.08);
+  color: var(--gold-400);
+}
+
+.btn-danger,
+.btn.danger {
+  border: 1px solid rgba(239,68,68,0.35);
+  color: #fca5a5;
+  background: transparent;
+  box-shadow: none;
+}
+
+.btn-danger:hover,
+.btn.danger:hover {
+  background: rgba(239,68,68,0.08);
+  border-color: rgba(239,68,68,0.5);
+}
+
+.btn-small,
+.btn.small {
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+}
+
+.btn-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: 600 11px/1 var(--font-sans);
+  letter-spacing: 0.1em;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(230,192,137,0.32);
+  background: rgba(230,192,137,0.08);
+  color: var(--text-muted);
+  box-shadow: inset 0 0 12px rgba(230,192,137,0.05);
+}
+
+.toast {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 18px;
+  border-radius: 14px;
+  background: rgba(15,19,22,0.92);
+  border: 1px solid rgba(230,192,137,0.32);
+  box-shadow: 0 20px 48px rgba(0,0,0,0.55);
+  color: var(--text-strong);
+  pointer-events: auto;
+}
+
+.toast .toast-message {
+  font: 600 12px/1.4 var(--font-sans);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.attachment-preview-backdrop {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(5,7,10,0.78);
+  backdrop-filter: blur(18px);
+  z-index: 180;
+}
+
+.attachment-preview-backdrop[data-open="true"] {
+  display: flex;
+}
+
+.attachment-preview-panel {
+  width: min(920px, calc(100vw - 32px));
+  max-height: min(90vh, 96svh);
+  background: linear-gradient(165deg, rgba(21,26,30,0.95), rgba(12,16,18,0.92));
+  border: 1px solid rgba(201,168,106,0.34);
+  border-radius: 24px;
+  box-shadow: 0 32px 64px rgba(0,0,0,0.72), 0 0 34px rgba(227,198,139,0.2);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+}
+
+.attachment-preview-body {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 220px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(201,168,106,0.26);
+  background: rgba(12,16,18,0.82);
+  box-shadow: inset 0 0 22px rgba(0,0,0,0.45);
+  overflow: auto;
+}
+
+.attachment-preview-body img,
+.attachment-preview-body video,
+.attachment-preview-body iframe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  max-height: 70vh;
+  border-radius: 14px;
+  background: #050607;
+}
+
+.attachment-preview-body video { background: #000; }
+.attachment-preview-body iframe { border: 0; min-height: 60vh; }
+
+.attachment-preview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.attachment-preview-title {
+  margin: 0;
+  font: 600 18px/1.2 var(--font-heading);
+  color: var(--gold-400);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.attachment-preview-meta {
+  color: var(--text-muted);
+  font: 12px/1.5 var(--font-sans);
+  letter-spacing: 0.1em;
+}
+
+.attachment-preview-close {
+  border: 1px solid rgba(201,168,106,0.32);
+  background: rgba(15,19,22,0.8);
+  color: var(--gold-400);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  transition: border-color var(--transition), transform var(--transition);
+}
+
+.attachment-preview-close:hover {
+  border-color: rgba(227,198,139,0.6);
+  transform: translateY(-1px);
+}
+
+.attachment-preview-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--text-muted);
+  font: 14px/1.6 var(--font-sans);
+  text-align: center;
+}
+
+.attachment-preview-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 3px solid rgba(201,168,106,0.24);
+  border-top-color: var(--gold-400);
+  animation: attachment-preview-spin .9s linear infinite;
+}
+
+.attachment-preview-loading-text {
+  letter-spacing: 0.08em;
+}
+
+.attachment-preview-error {
+  color: #fca5a5;
+  font: 14px/1.6 var(--font-sans);
+  padding: 18px;
+  text-align: center;
+}
+
+.attachment-preview-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.attachment-preview-list li {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(201,168,106,0.28);
+  background: rgba(12,16,18,0.78);
+  font: 13px/1.5 var(--font-sans);
+  letter-spacing: 0.04em;
+  color: var(--text-strong);
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.attachment-preview-list li .entry-size {
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.attachment-preview-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.attachment-preview-tree ul {
+  list-style: none;
+  margin: 6px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+}
+
+.attachment-preview-tree summary {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(201,168,106,0.28);
+  background: rgba(12,16,18,0.78);
+  font: 600 13px/1.4 var(--font-sans);
+  letter-spacing: 0.08em;
+  color: var(--text-strong);
+}
+
+.attachment-preview-tree summary::-webkit-details-marker { display: none; }
+
+.attachment-preview-tree .tree-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(201,168,106,0.26);
+  background: rgba(12,16,18,0.78);
+  font: 13px/1.5 var(--font-sans);
+  letter-spacing: 0.04em;
+  color: var(--text-strong);
+}
+
+.attachment-preview-tree .entry-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.attachment-preview-tree .entry-size {
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.attachment-preview-tree summary .entry-size {
+  font-weight: 500;
+}
+
+.attachment-preview-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.attachment-preview-download {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(201,168,106,0.36);
+  background: rgba(15,19,22,0.85);
+  color: var(--gold-400);
+  font: 600 12px/1 var(--font-sans);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.attachment-preview-download:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(227,198,139,0.25);
+}
+
+@keyframes attachment-preview-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 768px) {
+  body::after {
+    opacity: 0.24;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  body {
+    background: var(--bg-void);
+  }
+  body::before,
+  body::after,
+  .scanlines {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/public/assets/img/golden-grid.svg
+++ b/public/assets/img/golden-grid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160">
+  <path fill="rgba(201,168,106,0.05)" d="M0 79h160v2H0zM79 0h2v160h-2z" />
+</svg>

--- a/resources/views/memo/index.phtml
+++ b/resources/views/memo/index.phtml
@@ -1,3 +1,7 @@
+<?php
+$commonCssPath = __DIR__ . '/../../..' . '/public/assets/css/common.css';
+$commonCssVersion = is_file($commonCssPath) ? filemtime($commonCssPath) : time();
+?>
 <!doctype html>
 <html lang="zh-Hans">
 <head>
@@ -6,65 +10,13 @@
 <title>自适应备忘录 · 单文件</title>
 <meta name="color-scheme" content="dark"/>
 <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+<link rel="preload" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>" as="style" crossorigin="anonymous"/>
+<link rel="stylesheet" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>"/>
 <style>
-  :root{
-    --bg-void:#0A0C0E;
-    --bg-elev-1:#0F1316;
-    --bg-elev-2:#151A1E;
-    --gold-700:#8E6B3D;
-    --gold-600:#CFA66B;
-    --gold-500:#E6C089;
-    --gold-400:#F4D8A4;
-    --accent-emerald:#23C4A2;
-    --accent-crimson:#EF6D6D;
-    --accent-cyan:#4BC3D1;
-    --text-strong:#F2EEE6;
-    --text-muted:#9F998E;
-    --text-dim:#716B61;
-    --divider:rgba(230,192,137,.2);
-    --text:var(--text-strong);
-    --bg:var(--bg-void);
-    --panel:rgba(21,26,30,.9);
-    --sidebar-width:clamp(240px,26vw,320px);
-    --panel-strong:rgba(15,19,22,.94);
-    --grid:rgba(201,168,106,.12);
-    --grid-strong:rgba(201,168,106,.18);
-    --glow:var(--gold-500);
-    --glow-soft:rgba(227,198,139,.28);
-    --glow-strong:rgba(227,198,139,.42);
-    --danger:var(--accent-crimson);
-    --danger-soft:rgba(209,75,75,.32);
-    --accent:var(--gold-400);
-    --accent-soft:rgba(227,198,139,.18);
-    --border:rgba(201,168,106,.36);
-    --border-soft:rgba(201,168,106,.2);
-    --shadow:0 24px 60px rgba(0,0,0,.72);
-    --grid-size:72px;
-    --transition:300ms cubic-bezier(.22,.61,.36,1);
-  }
-  *,*::before,*::after{box-sizing:border-box}
-  html,body{margin:0;min-height:100vh;background:var(--bg-void);color:var(--text-strong);font:16px/1.65 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow-x:hidden}
   body{--item-padding:18px 16px;--item-gap:12px;--item-radius:18px;--item-line:36px;--item-desc-lines:3;--item-grid-gap:20px;}
   body[data-density='compact']{--item-padding:14px 14px;--item-gap:8px;--item-radius:16px;--item-line:28px;--item-desc-lines:2;--item-grid-gap:16px;}
 
-  body::before{content:"";position:fixed;inset:0;background:
-    linear-gradient(180deg,rgba(10,12,14,.45),rgba(10,12,14,.82)),
-    url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cpath fill="rgba(201,168,106,0.05)" d="M0 79h160v2H0zm79-79h2v160h-2z"/%3E%3C/svg%3E');
-    background-size:cover,160px 160px;opacity:.58;pointer-events:none;z-index:-3;
-  }
-  body::after{content:"";position:fixed;inset:0;background:
-      radial-gradient(1200px 700px at 70% -10%,rgba(227,198,139,.06),transparent 60%),
-      linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
-      repeating-linear-gradient(0deg,rgba(75,195,209,.08) 0,rgba(75,195,209,.08) 1px,transparent 1px,transparent calc(var(--grid-size))),
-      repeating-linear-gradient(90deg,rgba(201,168,106,.12) 0,rgba(201,168,106,.12) 1px,transparent 1px,transparent calc(var(--grid-size)));
-    mix-blend-mode:screen;opacity:.32;pointer-events:none;z-index:-4;background-size:100% 100%,100% 100%,var(--grid-size) var(--grid-size),var(--grid-size) var(--grid-size);
-    background-attachment:fixed;
-  }
-  .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.18}
-  a{color:inherit;text-decoration:none}
+  :root{--sidebar-width:clamp(240px,26vw,320px);--grid:rgba(201,168,106,.12);--grid-strong:rgba(201,168,106,.18);--accent:var(--gold-400);--accent-soft:rgba(227,198,139,.18);}
   .app{display:flex;min-height:100vh;position:relative;z-index:0}
   .sidebar{position:fixed;top:0;left:0;bottom:0;width:var(--sidebar-width);overflow:auto;background:linear-gradient(165deg,rgba(12,14,18,.94) 0%,rgba(15,19,22,.9) 55%,rgba(21,26,30,.9) 100%);border-right:1px solid var(--border);box-shadow:inset 0 0 0 1px rgba(201,168,106,.08),0 18px 45px rgba(0,0,0,.45);padding:20px;backdrop-filter:blur(18px) saturate(170%);
     transition:transform var(--transition),box-shadow var(--transition);
@@ -80,22 +32,7 @@
   .dropdown-menu[data-open="true"]{display:flex}
   .dropdown-menu a{display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:10px;color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;text-decoration:none;transition:background var(--transition),color var(--transition)}
   .dropdown-menu a:hover{background:rgba(201,168,106,.12);color:var(--gold-400)}
-  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 16px;border-radius:14px;border:1px solid transparent;background:transparent;color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:none;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),background var(--transition),color var(--transition);cursor:pointer}
-  .btn::before{content:"";position:absolute;inset:0;border-radius:inherit;box-shadow:inset 0 0 0 1px rgba(227,198,139,.08);opacity:0;transition:opacity var(--transition)}
-  .btn:hover::before{opacity:1}
-  .btn-primary,.btn.acc{background:linear-gradient(135deg,var(--gold-500),var(--gold-600));color:#1b1306;border-color:rgba(142,107,61,.75);box-shadow:0 16px 34px rgba(227,198,139,.24),0 0 24px rgba(227,198,139,.18)}
-  .btn-primary:hover,.btn.acc:hover{transform:translateY(-1px);box-shadow:0 20px 40px rgba(227,198,139,.3),0 0 30px rgba(227,198,139,.24)}
-  .btn-outline{border:1px solid rgba(230,192,137,.4);background:rgba(15,19,22,.6);color:var(--gold-500);box-shadow:0 12px 28px rgba(0,0,0,.32)}
-  .btn-outline:hover{border-color:rgba(230,192,137,.65);color:var(--gold-400)}
-  .btn-ghost{border:1px solid rgba(230,192,137,.25);background:transparent;color:var(--gold-500)}
-  .btn-ghost:hover{background:rgba(230,192,137,.08);color:var(--gold-400)}
-  .btn-danger,.btn.danger{border:1px solid rgba(239,68,68,.35);color:#fca5a5;background:transparent;box-shadow:none}
-  .btn-danger:hover,.btn.danger:hover{background:rgba(239,68,68,.08);border-color:rgba(239,68,68,.5)}
-  .btn-small,.btn.small{padding:8px 12px;border-radius:12px;font-size:11px;letter-spacing:.1em}
-  .btn:focus-visible{outline:none;box-shadow:0 0 0 3px rgba(230,192,137,.5)}
-  .btn-icon{font-size:14px;line-height:1}
   .btn-label{display:inline-flex}
-  .btn:active{transform:translateY(0);box-shadow:none}
 
   .section-title{font:600 12px/1 'Cinzel','Noto Serif SC',serif;text-transform:uppercase;letter-spacing:.24em;color:var(--gold-400);margin:14px 0 8px;text-shadow:0 0 14px rgba(227,198,139,.24)}
   .cat-list{display:flex;flex-direction:column;gap:8px}

--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -1,3 +1,7 @@
+  <?php
+  $commonCssPath = __DIR__ . '/../../..' . '/public/assets/css/common.css';
+  $commonCssVersion = is_file($commonCssPath) ? filemtime($commonCssPath) : time();
+  ?>
   <!doctype html>
   <html lang="zh-Hans">
   <head>
@@ -6,25 +10,10 @@
     <title>详情 · <?php echo h($it['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+    <link rel="preload" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>" as="style" crossorigin="anonymous"/>
+    <link rel="stylesheet" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>"/>
     <style>
       :root{
-        --bg-void:#0A0C0E;
-        --bg-elev-1:#0F1316;
-        --bg-elev-2:#151A1E;
-        --gold-700:#AA8C54;
-        --gold-600:#C9A86A;
-        --gold-500:#D1B274;
-        --gold-400:#E3C68B;
-        --accent-emerald:#24C2A0;
-        --accent-crimson:#D14B4B;
-        --accent-cyan:#4BC3D1;
-        --text-strong:#E8E5DF;
-        --text-dim:#A7A39A;
-        --text-muted:#7A766E;
-        --divider:rgba(201,168,106,.18);
         --r-xs:6px;
         --r-sm:10px;
         --r-md:14px;
@@ -35,41 +24,9 @@
         --t:300ms;
         --t-slow:450ms;
         --ease:cubic-bezier(.22,.61,.36,1);
-        --bg:var(--bg-void);
-        --panel:rgba(21,26,30,.9);
-        --panel-strong:rgba(15,19,22,.94);
-        --glow:var(--gold-500);
-        --glow-soft:rgba(227,198,139,.2);
-        --glow-strong:rgba(227,198,139,.38);
-        --text:var(--text-strong);
-        --border:rgba(201,168,106,.36);
-        --border-soft:rgba(201,168,106,.18);
-        --danger:var(--accent-crimson);
-        --danger-soft:rgba(209,75,75,.32);
         --grid-size:64px;
-        --transition:var(--t) var(--ease);
       }
-      *,*::before,*::after{box-sizing:border-box}
-      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.65 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow-x:hidden}
-      body{background:
-        radial-gradient(1200px 700px at 70% -10%,rgba(227,198,139,.06),transparent 60%),
-        linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
-        #0A0C0E;
-      }
-      body::before{content:"";position:fixed;inset:0;background:
-        linear-gradient(180deg,rgba(10,12,14,.45),rgba(10,12,14,.85)),
-        url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cpath fill="rgba(201,168,106,0.05)" d="M0 79h160v2H0zm79-79h2v160h-2z"/%3E%3C/svg%3E');
-        background-size:cover,160px 160px;opacity:.55;pointer-events:none;z-index:-2;
-      }
-      body::after{content:"";position:fixed;inset:0;background:
-        repeating-linear-gradient(0deg,rgba(75,195,209,.08) 0,rgba(75,195,209,.08) 1px,transparent 1px,transparent var(--grid-size)),
-        repeating-linear-gradient(90deg,rgba(201,168,106,.12) 0,rgba(201,168,106,.12) 1px,transparent 1px,transparent var(--grid-size));
-        background-size:var(--grid-size) var(--grid-size);
-        mix-blend-mode:screen;opacity:.28;pointer-events:none;z-index:-3;background-attachment:fixed;
-      }
-      .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.18}
-      a{color:inherit;text-decoration:none}
-      h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
+      h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC','Songti SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
       .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px;position:relative;z-index:0}
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.2);opacity:.6;pointer-events:none}
       .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(227,198,139,.65);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.62));color:#1b1306;cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 14px 32px rgba(227,198,139,.25),0 0 24px rgba(227,198,139,.18);overflow:hidden}
@@ -140,60 +97,12 @@
       .save-tip.dirty{color:var(--accent-crimson)}
       .save-tip.show{display:inline-block}
       .placeholder-muted{color:var(--text-muted)}
-      .toast{position:fixed;top:18px;right:18px;min-width:220px;padding:14px 18px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.34);background:rgba(12,16,18,.9);color:var(--text-strong);box-shadow:0 20px 44px rgba(0,0,0,.58);display:flex;gap:12px;align-items:flex-start;backdrop-filter:blur(18px);z-index:10}
+      .toast{position:fixed;top:18px;right:18px;min-width:220px;backdrop-filter:blur(18px);z-index:10}
       .toast.error{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:0 22px 46px rgba(209,75,75,.28)}
       .toast .icon{font-size:18px;color:var(--gold-400)}
       .toast.error .icon{color:var(--accent-crimson)}
-      .toast .body{flex:1;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .toast .body{flex:1;font:14px/1.6 var(--font-sans);letter-spacing:.08em}
       .toast button{background:none;border:0;color:inherit;cursor:pointer}
-      .attachment-preview-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(5,7,10,.78);backdrop-filter:blur(18px);z-index:180}
-      .attachment-preview-backdrop[data-open="true"]{display:flex}
-      .attachment-preview-panel{width:min(920px,calc(100vw - 32px));max-height:min(90vh,96svh);background:linear-gradient(165deg,rgba(21,26,30,.95),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.34);border-radius:24px;box-shadow:0 32px 64px rgba(0,0,0,.68),0 0 34px rgba(227,198,139,.2);padding:20px;display:flex;flex-direction:column;gap:16px;position:relative}
-      .attachment-preview-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-      .attachment-preview-title{margin:0;font:600 18px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
-      .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
-      .attachment-preview-close{border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.8);color:var(--gold-400);border-radius:50%;width:36px;height:36px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;transition:border-color var(--transition),transform var(--transition)}
-      .attachment-preview-close:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
-      .attachment-preview-body{position:relative;flex:1 1 auto;min-height:220px;padding:16px;border-radius:18px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.82);box-shadow:inset 0 0 22px rgba(0,0,0,.45);overflow:auto}
-      .attachment-preview-body img,.attachment-preview-body video,.attachment-preview-body iframe{display:block;width:100%;height:100%;max-height:70vh;border-radius:14px;background:#050607}
-      .attachment-preview-body video{background:#000}
-      .attachment-preview-body iframe{border:0;min-height:60vh}
-      .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 'Inter','Noto Sans SC',sans-serif;text-align:center}
-      .attachment-preview-spinner{width:40px;height:40px;border-radius:50%;border:3px solid rgba(201,168,106,.24);border-top-color:var(--gold-400);animation:attachment-preview-spin .9s linear infinite}
-      .attachment-preview-loading-text{letter-spacing:.08em}
-      @keyframes attachment-preview-spin{to{transform:rotate(360deg)}}
-      .attachment-preview-error{color:#fca5a5;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;padding:18px;text-align:center}
-      .attachment-preview-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-      .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
-      .attachment-preview-list li .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
-      .attachment-preview-tree{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-      .attachment-preview-tree ul{list-style:none;margin:6px 0 0;padding-left:18px;display:grid;gap:6px}
-      .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;color:var(--text-strong)}
-      .attachment-preview-tree summary::-webkit-details-marker{display:none}
-      .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong)}
-      .attachment-preview-tree .entry-label{display:flex;align-items:center;gap:8px;min-width:0}
-      .attachment-preview-tree .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
-      .attachment-preview-tree summary .entry-size{font-weight:500}
-      .attachment-docx{color:var(--text-strong);font:400 14px/1.75 'Noto Sans SC','Inter',sans-serif;display:grid;gap:14px}
-      .attachment-docx h1,.attachment-docx h2,.attachment-docx h3,.attachment-docx h4{color:var(--gold-400);margin:12px 0 6px;font-weight:600}
-      .attachment-docx table{width:100%;border-collapse:collapse;margin:12px 0;border:1px solid rgba(201,168,106,.24)}
-      .attachment-docx th,.attachment-docx td{border:1px solid rgba(201,168,106,.24);padding:6px 8px}
-      .attachment-docx a{color:var(--gold-400)}
-      .attachment-excel{display:grid;gap:16px}
-      .attachment-excel .excel-sheet{border:1px solid rgba(201,168,106,.28);border-radius:14px;background:rgba(12,16,18,.78);padding:14px;box-shadow:inset 0 0 18px rgba(0,0,0,.36)}
-      .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
-      .attachment-excel .excel-table{overflow:auto;border-radius:10px;border:1px solid rgba(201,168,106,.24)}
-      .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);background:rgba(12,16,18,.88)}
-      .attachment-excel th,.attachment-excel td{border:1px solid rgba(201,168,106,.2);padding:6px 8px;text-align:left}
-      .attachment-excel tbody tr:nth-child(even){background:rgba(201,168,106,.08)}
-      .attachment-preview-tree{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-      .attachment-preview-tree ul{list-style:none;margin:6px 0 0;padding-left:18px;display:grid;gap:6px}
-      .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;color:var(--text-strong)}
-      .attachment-preview-tree summary::-webkit-details-marker{display:none}
-      .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong)}
-      .attachment-preview-tree .entry-label{display:flex;align-items:center;gap:8px;min-width:0}
-      .attachment-preview-tree .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
-      .attachment-preview-tree summary .entry-size{font-weight:500}
       .attachment-docx{color:var(--text-strong);font:400 14px/1.75 'Noto Sans SC','Inter',sans-serif;display:grid;gap:14px}
       .attachment-docx h1,.attachment-docx h2,.attachment-docx h3,.attachment-docx h4{color:var(--gold-400);margin:12px 0 6px;font-weight:600}
       .attachment-docx table{width:100%;border-collapse:collapse;margin:12px 0;border:1px solid rgba(201,168,106,.24)}
@@ -207,8 +116,6 @@
       .attachment-excel th,.attachment-excel td{border:1px solid rgba(201,168,106,.2);padding:6px 8px;text-align:left}
       .attachment-excel tbody tr:nth-child(even){background:rgba(201,168,106,.08)}
       .attachment-preview-footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
-      .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
-      .attachment-preview-download:hover{transform:translateY(-1px);box-shadow:0 16px 32px rgba(227,198,139,.25)}
     </style>
     <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -1,3 +1,7 @@
+  <?php
+  $commonCssPath = __DIR__ . '/../../..' . '/public/assets/css/common.css';
+  $commonCssVersion = is_file($commonCssPath) ? filemtime($commonCssPath) : time();
+  ?>
   <!doctype html>
   <html lang="zh-Hans">
   <head>
@@ -6,25 +10,10 @@
     <title>思维导图编辑器 · <?php echo h($mind['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+    <link rel="preload" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>" as="style" crossorigin="anonymous"/>
+    <link rel="stylesheet" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>"/>
     <style>
       :root{
-        --bg-void:#0A0C0E;
-        --bg-elev-1:#0F1316;
-        --bg-elev-2:#151A1E;
-        --gold-700:#AA8C54;
-        --gold-600:#C9A86A;
-        --gold-500:#D1B274;
-        --gold-400:#E3C68B;
-        --accent-emerald:#24C2A0;
-        --accent-crimson:#D14B4B;
-        --accent-cyan:#4BC3D1;
-        --text-strong:#E8E5DF;
-        --text-dim:#A7A39A;
-        --text-muted:#7A766E;
-        --divider:rgba(201,168,106,.18);
         --r-xs:6px;
         --r-sm:10px;
         --r-md:14px;
@@ -35,47 +24,16 @@
         --t:300ms;
         --t-slow:450ms;
         --ease:cubic-bezier(.22,.61,.36,1);
-        --bg:var(--bg-void);
-        --panel:rgba(21,26,30,.92);
-        --panel-strong:rgba(15,19,22,.95);
-        --glow:var(--gold-500);
-        --glow-soft:rgba(227,198,139,.26);
-        --glow-strong:rgba(227,198,139,.4);
-        --text:var(--text-strong);
-        --border:rgba(201,168,106,.38);
-        --border-soft:rgba(201,168,106,.18);
         --grid:rgba(201,168,106,.18);
         --grid-strong:rgba(201,168,106,.3);
         --fiber:var(--gold-500);
         --fiber-soft:rgba(227,198,139,.32);
-        --danger:var(--accent-crimson);
         --grid-size:72px;
-        --transition:var(--t) var(--ease);
         --safe-top:env(safe-area-inset-top, 0px);
         --safe-right:env(safe-area-inset-right, 0px);
         --safe-bottom:env(safe-area-inset-bottom, 0px);
         --safe-left:env(safe-area-inset-left, 0px);
       }
-      *,*::before,*::after{box-sizing:border-box}
-      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.6 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow:hidden}
-      body{background:
-        radial-gradient(1200px 700px at 72% -10%,rgba(227,198,139,.06),transparent 60%),
-        linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
-        #0A0C0E;
-      }
-      body::before{content:"";position:fixed;inset:0;background:
-        linear-gradient(180deg,rgba(10,12,14,.45),rgba(10,12,14,.82)),
-        url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cpath fill="rgba(201,168,106,0.05)" d="M0 79h160v2H0zm79-79h2v160h-2z"/%3E%3C/svg%3E');
-        background-size:cover,160px 160px;opacity:.6;pointer-events:none;z-index:-2;
-      }
-      body::after{content:"";position:fixed;inset:0;background:
-        repeating-linear-gradient(0deg,rgba(75,195,209,.08) 0,rgba(75,195,209,.08) 1px,transparent 1px,transparent var(--grid-size)),
-        repeating-linear-gradient(90deg,rgba(201,168,106,.12) 0,rgba(201,168,106,.12) 1px,transparent 1px,transparent var(--grid-size));
-        background-size:var(--grid-size) var(--grid-size);
-        mix-blend-mode:screen;opacity:.3;pointer-events:none;z-index:-3;background-attachment:fixed;
-      }
-      .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.18}
-      a{color:inherit;text-decoration:none}
       .mind-shell{position:relative;min-height:100vh;min-height:100dvh;height:100vh;height:100dvh;display:flex;flex-direction:column;gap:0;padding:0;overflow:hidden}
       @media (max-width:900px){.mind-shell{padding:0}}
       .mind-info-bar{position:absolute;top:calc(var(--safe-top) + 28px);left:calc(var(--safe-left) + 28px);display:flex;flex-direction:column;gap:12px;padding:14px 18px;border-radius:20px;border:1px solid rgba(201,168,106,.32);background:linear-gradient(180deg,rgba(21,26,30,.92),rgba(12,16,18,.88));box-shadow:0 18px 48px rgba(0,0,0,.55),0 0 28px rgba(227,198,139,.14) inset;backdrop-filter:blur(16px);min-width:260px;max-width:min(460px,calc(100% - 56px));pointer-events:auto;z-index:20;overflow:visible;max-height:320px;transition:max-height var(--t-fast) var(--ease),padding var(--t-fast) var(--ease),gap var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),background var(--t-fast) var(--ease),box-shadow var(--t-fast) var(--ease)}
@@ -116,29 +74,8 @@
       .mind-import-footer{display:flex;justify-content:flex-end}
       .mind-import-footer button{padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
       .mind-import-footer button:hover{transform:translateY(-2px);box-shadow:0 12px 26px rgba(227,198,139,.22)}
-      .attachment-preview-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(5,7,10,.78);backdrop-filter:blur(18px);z-index:280}
-      .attachment-preview-backdrop[data-open="true"]{display:flex}
-      .attachment-preview-panel{width:min(960px,calc(100vw - 32px));max-height:min(90vh,96svh);background:linear-gradient(165deg,rgba(21,26,30,.95),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.34);border-radius:24px;box-shadow:0 32px 64px rgba(0,0,0,.72),0 0 34px rgba(227,198,139,.2);padding:20px;display:flex;flex-direction:column;gap:16px;position:relative}
-      .attachment-preview-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-      .attachment-preview-title{margin:0;font:600 18px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
-      .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
-      .attachment-preview-close{border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.8);color:var(--gold-400);border-radius:50%;width:36px;height:36px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;transition:border-color var(--transition),transform var(--transition)}
-      .attachment-preview-close:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
-      .attachment-preview-body{position:relative;flex:1 1 auto;min-height:220px;padding:16px;border-radius:18px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.82);box-shadow:inset 0 0 22px rgba(0,0,0,.45);overflow:auto}
-      .attachment-preview-body img,.attachment-preview-body video,.attachment-preview-body iframe{display:block;width:100%;height:100%;max-height:70vh;border-radius:14px;background:#050607}
-      .attachment-preview-body video{background:#000}
-      .attachment-preview-body iframe{border:0;min-height:60vh}
-      .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 'Inter','Noto Sans SC',sans-serif;text-align:center}
-      .attachment-preview-spinner{width:40px;height:40px;border-radius:50%;border:3px solid rgba(201,168,106,.24);border-top-color:var(--gold-400);animation:attachment-preview-spin .9s linear infinite}
-      .attachment-preview-loading-text{letter-spacing:.08em}
-      @keyframes attachment-preview-spin{to{transform:rotate(360deg)}}
-      .attachment-preview-error{color:#fca5a5;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;padding:18px;text-align:center}
-      .attachment-preview-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-      .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
-      .attachment-preview-list li .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
-      .attachment-preview-footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
-      .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
-      .attachment-preview-download:hover{transform:translateY(-1px);box-shadow:0 16px 32px rgba(227,198,139,.25)}
+      .attachment-preview-backdrop{z-index:280}
+      .attachment-preview-panel{width:min(960px,calc(100vw - 32px))}
       .map-back{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.08);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400);transition:background var(--transition),border-color var(--transition),transform var(--transition)}
       .map-back:hover{border-color:rgba(227,198,139,.6);background:rgba(201,168,106,.16);transform:translateY(-1px)}
       .mind-info-row .map-title-input{flex:1;min-width:0}

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -1,3 +1,7 @@
+  <?php
+  $commonCssPath = __DIR__ . '/../../..' . '/public/assets/css/common.css';
+  $commonCssVersion = is_file($commonCssPath) ? filemtime($commonCssPath) : time();
+  ?>
   <!doctype html>
   <html lang="zh-Hans">
   <head>
@@ -6,25 +10,10 @@
     <title>新建备忘录</title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
+    <link rel="preload" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>" as="style" crossorigin="anonymous"/>
+    <link rel="stylesheet" href="/assets/css/common.css?v=<?= $commonCssVersion; ?>"/>
     <style>
       :root{
-        --bg-void:#0A0C0E;
-        --bg-elev-1:#0F1316;
-        --bg-elev-2:#151A1E;
-        --gold-700:#AA8C54;
-        --gold-600:#C9A86A;
-        --gold-500:#D1B274;
-        --gold-400:#E3C68B;
-        --accent-emerald:#24C2A0;
-        --accent-crimson:#D14B4B;
-        --accent-cyan:#4BC3D1;
-        --text-strong:#E8E5DF;
-        --text-dim:#A7A39A;
-        --text-muted:#7A766E;
-        --divider:rgba(201,168,106,.18);
         --r-xs:6px;
         --r-sm:10px;
         --r-md:14px;
@@ -35,53 +24,13 @@
         --t:300ms;
         --t-slow:450ms;
         --ease:cubic-bezier(.22,.61,.36,1);
-        /* legacy tokens */
-        --bg:var(--bg-void);
-        --bg-alt:var(--bg-elev-1);
-        --panel:rgba(15,19,22,.86);
-        --panel-strong:rgba(21,26,30,.92);
-        --glow:var(--gold-500);
-        --glow-soft:rgba(227,198,139,.22);
-        --glow-strong:rgba(227,198,139,.4);
-        --text:var(--text-strong);
-        --border:rgba(201,168,106,.36);
-        --border-soft:rgba(201,168,106,.18);
-        --danger:var(--accent-crimson);
-        --danger-soft:rgba(209,75,75,.35);
         --grid-size:64px;
-        --transition:var(--t) var(--ease);
       }
-      *,*::before,*::after{box-sizing:border-box}
-      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.65 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow-x:hidden}
-      body{background:
-        radial-gradient(1200px 700px at 70% -10%,rgba(227,198,139,.06),transparent 60%),
-        linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
-        #0A0C0E;
-      }
-      body::before{content:"";position:fixed;inset:0;background:
-        linear-gradient(180deg,rgba(10,12,14,.45),rgba(10,12,14,.8)),
-        url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Cpath fill="rgba(201,168,106,0.05)" d="M0 79h160v2H0zm79-79h2v160h-2z"/%3E%3C/svg%3E');
-        background-size:cover,160px 160px;opacity:.55;pointer-events:none;z-index:-2;
-      }
-      body::after{content:"";position:fixed;inset:0;background:
-        repeating-linear-gradient(0deg,rgba(75,195,209,.08) 0,rgba(75,195,209,.08) 1px,transparent 1px,transparent var(--grid-size)),
-        repeating-linear-gradient(90deg,rgba(201,168,106,.12) 0,rgba(201,168,106,.12) 1px,transparent 1px,transparent var(--grid-size));
-        background-size:var(--grid-size) var(--grid-size);
-        mix-blend-mode:screen;opacity:.28;pointer-events:none;z-index:-3;background-attachment:fixed;
-      }
-      .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.18}
-      a{color:inherit;text-decoration:none}
-      h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
+      h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC','Songti SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
       .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px;position:relative;z-index:0}
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.18);opacity:.65;pointer-events:none}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.92));border:1px solid rgba(201,168,106,.28);border-radius:var(--r-lg);padding:24px;box-shadow:var(--shadow-1);backdrop-filter:blur(14px)}
       .card::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-lg) - 4px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 34px rgba(227,198,139,.08);pointer-events:none;opacity:.9}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(227,198,139,.65);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.62));color:#1b1306;cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 14px 32px rgba(227,198,139,.25),0 0 24px rgba(227,198,139,.18);overflow:hidden}
-      .btn::after{content:none}
-      .btn:hover{transform:translateY(-2px);box-shadow:0 18px 36px rgba(227,198,139,.3),0 0 28px rgba(227,198,139,.24)}
-      .btn:active{transform:translateY(0);box-shadow:0 8px 20px rgba(227,198,139,.22)}
-      .btn.acc{background:linear-gradient(135deg,rgba(227,198,139,.92),rgba(201,168,106,.72));color:#120d05}
-      .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 2px rgba(227,198,139,.25)}
       .row{display:grid;grid-template-columns:2fr 1fr auto;gap:16px;margin-bottom:20px;align-items:center}
       .row input,.row select{padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 15px/1.4 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
       .row input::placeholder{color:var(--text-muted)}


### PR DESCRIPTION
## Summary
- extract shared theme tokens, button components, and attachment preview styles into a reusable public/assets/css/common.css with local font fallbacks
- add a reusable golden grid background asset and transparency toggles for accessibility preferences
- update memo view templates to consume the shared stylesheet, drop duplicated Google Fonts links, and keep only page-specific styling knobs

## Testing
- php -l resources/views/memo/index.phtml
- php -l resources/views/memo/item.phtml
- php -l resources/views/memo/map_edit.phtml
- php -l resources/views/memo/new.phtml

------
https://chatgpt.com/codex/tasks/task_e_68e81fd8b93083289f54716b9ed745cd