### PR TITLE
适配子目录部署的静态资源路径

### DIFF
--- a/memo.php
+++ b/memo.php
@@ -117,6 +117,53 @@ function memo_allowed_upload_mime_map(): array {
   return MemoEnvironment::runtimeConfig()->allowedMimes();
 }
 
+function memo_base_path(): string {
+  static $basePath = null;
+  if ($basePath !== null) {
+    return $basePath;
+  }
+
+  $basePath = '';
+  $config = MemoEnvironment::config();
+  if ($config instanceof \Core\Config) {
+    $configured = $config->get('app.base_url');
+    if (is_string($configured) && $configured !== '') {
+      $parsed = parse_url($configured, PHP_URL_PATH);
+      if (is_string($parsed) && $parsed !== '') {
+        $basePath = '/' . trim($parsed, '/');
+      }
+    }
+  }
+
+  if ($basePath === '' || $basePath === '/') {
+    $basePath = '';
+    $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
+    if (is_string($scriptName) && $scriptName !== '') {
+      $directory = str_replace('\\', '/', dirname($scriptName));
+      if ($directory !== '/' && $directory !== '.' && $directory !== '') {
+        $basePath = '/' . trim($directory, '/');
+      }
+    }
+  }
+
+  if ($basePath === '/' || $basePath === '') {
+    $basePath = '';
+  }
+
+  return $basePath;
+}
+
+function memo_asset(string $path): string {
+  $normalized = '/' . ltrim($path, '/');
+  $basePath = memo_base_path();
+
+  if ($basePath === '' || $basePath === '/') {
+    return $normalized;
+  }
+
+  return rtrim($basePath, '/') . $normalized;
+}
+
 function memo_extension_for_mime(string $mime): ?string {
   $map = memo_allowed_upload_mime_map();
   $normalized = strtolower(trim($mime));

--- a/resources/views/memo/index.phtml
+++ b/resources/views/memo/index.phtml
@@ -7,8 +7,8 @@
 <meta name="color-scheme" content="dark"/>
 <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
 <?php $assetVersion = function_exists('config') ? config('app.asset_version', '1.0.0') : '1.0.0'; ?>
-<link rel="stylesheet" href="/css/common.css?v=<?= h($assetVersion); ?>">
-<link rel="stylesheet" href="/css/index.css?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/common.css'); ?>?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/index.css'); ?>?v=<?= h($assetVersion); ?>">
 <script>
   window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
   (function () {

--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -7,8 +7,8 @@
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
 <?php $assetVersion = function_exists('config') ? config('app.asset_version', '1.0.0') : '1.0.0'; ?>
-<link rel="stylesheet" href="/css/common.css?v=<?= h($assetVersion); ?>">
-<link rel="stylesheet" href="/css/item.css?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/common.css'); ?>?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/item.css'); ?>?v=<?= h($assetVersion); ?>">
 <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
       (function () {

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -7,8 +7,8 @@
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
 <?php $assetVersion = function_exists('config') ? config('app.asset_version', '1.0.0') : '1.0.0'; ?>
-<link rel="stylesheet" href="/css/common.css?v=<?= h($assetVersion); ?>">
-<link rel="stylesheet" href="/css/map.css?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/common.css'); ?>?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/map.css'); ?>?v=<?= h($assetVersion); ?>">
 <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
       (function () {

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -7,8 +7,8 @@
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
 <?php $assetVersion = function_exists('config') ? config('app.asset_version', '1.0.0') : '1.0.0'; ?>
-<link rel="stylesheet" href="/css/common.css?v=<?= h($assetVersion); ?>">
-<link rel="stylesheet" href="/css/item.css?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/common.css'); ?>?v=<?= h($assetVersion); ?>">
+<link rel="stylesheet" href="<?= memo_asset('css/item.css'); ?>?v=<?= h($assetVersion); ?>">
 <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
       (function () {


### PR DESCRIPTION
## Summary
- 新增 `memo_base_path`/`memo_asset` 帮助函数，根据 APP_URL 或脚本路径生成基础路径
- 统一模板中的样式表引用，确保在子目录部署时能够正确加载资源

## Testing
- php -l memo.php
- php -l resources/views/memo/index.phtml

------
https://chatgpt.com/codex/tasks/task_e_68e83182f8bc83289e7526cfbd8fc1af