### PR TITLE
feat: support subdirectory deployments

### DIFF
--- a/app/Memo/Legacy/Environment.php
+++ b/app/Memo/Legacy/Environment.php
@@ -11,13 +11,17 @@ final class Environment
     private static ?RuntimeConfig $runtimeConfig = null;
     private static ?string $csrfToken = null;
     private static bool $securityHeadersApplied = false;
+    private static string $basePath = '';
+    private static string $baseUrl = '';
 
-    public static function bootstrap(Config $config, string $csrfToken, RuntimeConfig $runtimeConfig): void
+    public static function bootstrap(Config $config, string $csrfToken, RuntimeConfig $runtimeConfig, string $basePath = '', string $baseUrl = ''): void
     {
         self::$config = $config;
         self::$csrfToken = $csrfToken;
         self::$runtimeConfig = $runtimeConfig;
         self::$securityHeadersApplied = false;
+        self::$basePath = $basePath;
+        self::$baseUrl = $baseUrl;
     }
 
     public static function config(): ?Config
@@ -47,5 +51,15 @@ final class Environment
     public static function markSecurityHeadersApplied(): void
     {
         self::$securityHeadersApplied = true;
+    }
+
+    public static function basePath(): string
+    {
+        return self::$basePath;
+    }
+
+    public static function baseUrl(): string
+    {
+        return self::$baseUrl;
     }
 }

--- a/app/Memo/Legacy/LegacyMemoRunner.php
+++ b/app/Memo/Legacy/LegacyMemoRunner.php
@@ -18,8 +18,36 @@ final class LegacyMemoRunner
     public function handle(Request $request, string $csrfToken): void
     {
         $runtimeConfig = RuntimeConfig::fromConfig($this->config, $this->projectRoot);
-        Environment::bootstrap($this->config, $csrfToken, $runtimeConfig);
+        $basePath = $request->basePath();
+        $baseUrl = $this->resolveBaseUrl($request, $basePath);
+        Environment::bootstrap($this->config, $csrfToken, $runtimeConfig, $basePath, $baseUrl);
 
         require $this->projectRoot . '/memo.php';
+    }
+
+    private function resolveBaseUrl(Request $request, string $basePath): string
+    {
+        $configured = $this->config->get('app.base_url');
+        if (is_string($configured) && $configured !== '') {
+            return rtrim($configured, '/');
+        }
+
+        $host = $request->server('HTTP_HOST');
+        if (!is_string($host) || $host === '') {
+            return '';
+        }
+
+        $scheme = $request->server('REQUEST_SCHEME');
+        if (!is_string($scheme) || $scheme === '') {
+            $https = $request->server('HTTPS');
+            $scheme = (!empty($https) && strtolower((string) $https) !== 'off') ? 'https' : 'http';
+        }
+
+        $base = $scheme . '://' . $host;
+        if ($basePath !== '') {
+            $base .= $basePath;
+        }
+
+        return rtrim($base, '/');
     }
 }

--- a/memo.php
+++ b/memo.php
@@ -136,6 +136,55 @@ function memo_upload_accept_attribute(): string {
   return $accept;
 }
 
+function memo_base_path(): string {
+  return MemoEnvironment::basePath();
+}
+
+function memo_base_url(): string {
+  $baseUrl = MemoEnvironment::baseUrl();
+  if ($baseUrl !== '') {
+    return $baseUrl;
+  }
+
+  $basePath = memo_base_path();
+  if ($basePath === '') {
+    return '';
+  }
+
+  return $basePath;
+}
+
+function memo_public_url(string $path = ''): string {
+  $normalized = '';
+  if ($path === '' || $path === '/') {
+    $normalized = '/';
+  } else {
+    $normalized = '/' . ltrim($path, '/');
+  }
+
+  $basePath = memo_base_path();
+  if ($basePath === '') {
+    return $normalized;
+  }
+
+  if ($normalized === '/' || $normalized === '') {
+    return $basePath . '/';
+  }
+
+  return $basePath . $normalized;
+}
+
+function memo_asset(string $path): string {
+  $relative = ltrim($path, '/');
+  $url = '/assets/' . $relative;
+  $basePath = memo_base_path();
+  if ($basePath !== '') {
+    return $basePath . $url;
+  }
+
+  return $url;
+}
+
 function memo_apply_default_security_headers(): void {
   if (headers_sent()) {
     return;

--- a/resources/views/memo/index.phtml
+++ b/resources/views/memo/index.phtml
@@ -6,10 +6,13 @@
 <title>自适应备忘录 · 单文件</title>
 <meta name="color-scheme" content="dark"/>
 <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="stylesheet" href="/assets/css/common.css?v=20240101"/>
-<link rel="stylesheet" href="/assets/css/memo-index.css?v=20240101"/>
+<base href="<?= h(memo_public_url('/')); ?>"/>
+<link rel="stylesheet" href="<?= h(memo_asset('css/common.css?v=20240101')); ?>"/>
+<link rel="stylesheet" href="<?= h(memo_asset('css/memo-index.css?v=20240101')); ?>"/>
 <script>
   window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
+  window.__BASE_PATH__ = '<?= h(memo_base_path()); ?>';
+  window.__BASE_URL__ = '<?= h(memo_base_url()); ?>';
   (function () {
     if (typeof window.fetch === 'function') {
       const originalFetch = window.fetch;

--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -6,10 +6,13 @@
     <title>详情 · <?php echo h($it['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="stylesheet" href="/assets/css/common.css?v=20240101"/>
-<link rel="stylesheet" href="/assets/css/memo-item.css?v=20240101"/>
+    <base href="<?= h(memo_public_url('/')); ?>"/>
+    <link rel="stylesheet" href="<?= h(memo_asset('css/common.css?v=20240101')); ?>"/>
+    <link rel="stylesheet" href="<?= h(memo_asset('css/memo-item.css?v=20240101')); ?>"/>
     <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
+      window.__BASE_PATH__ = '<?= h(memo_base_path()); ?>';
+      window.__BASE_URL__ = '<?= h(memo_base_url()); ?>';
       (function () {
         if (typeof window.fetch === 'function') {
           const originalFetch = window.fetch;

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -6,10 +6,13 @@
     <title>思维导图编辑器 · <?php echo h($mind['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="stylesheet" href="/assets/css/common.css?v=20240101"/>
-<link rel="stylesheet" href="/assets/css/memo-map.css?v=20240101"/>
+    <base href="<?= h(memo_public_url('/')); ?>"/>
+    <link rel="stylesheet" href="<?= h(memo_asset('css/common.css?v=20240101')); ?>"/>
+    <link rel="stylesheet" href="<?= h(memo_asset('css/memo-map.css?v=20240101')); ?>"/>
     <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
+      window.__BASE_PATH__ = '<?= h(memo_base_path()); ?>';
+      window.__BASE_URL__ = '<?= h(memo_base_url()); ?>';
       (function () {
         if (typeof window.fetch === 'function') {
           const originalFetch = window.fetch;

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -6,10 +6,13 @@
     <title>新建备忘录</title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="stylesheet" href="/assets/css/common.css?v=20240101"/>
-<link rel="stylesheet" href="/assets/css/memo-item.css?v=20240101"/>
+    <base href="<?= h(memo_public_url('/')); ?>"/>
+    <link rel="stylesheet" href="<?= h(memo_asset('css/common.css?v=20240101')); ?>"/>
+    <link rel="stylesheet" href="<?= h(memo_asset('css/memo-item.css?v=20240101')); ?>"/>
     <script>
       window.__CSRF_TOKEN__ = '<?= h(csrf_token()); ?>';
+      window.__BASE_PATH__ = '<?= h(memo_base_path()); ?>';
+      window.__BASE_URL__ = '<?= h(memo_base_url()); ?>';
       (function () {
         if (typeof window.fetch === 'function') {
           const originalFetch = window.fetch;


### PR DESCRIPTION
## Summary
- propagate the configured base path and URL into the legacy memo environment
- add runtime helpers for generating public and asset URLs that respect subdirectory deployments
- update memo views to rely on the helpers, inject a `<base>` tag, and expose the base path/URL to front-end scripts

## Testing
- php -l app/Memo/Legacy/Environment.php
- php -l app/Memo/Legacy/LegacyMemoRunner.php
- php -l memo.php
- php -l resources/views/memo/index.phtml
- php -l resources/views/memo/new.phtml
- php -l resources/views/memo/item.phtml
- php -l resources/views/memo/map_edit.phtml
- N/A (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68e8b7e72fbc83289864d7beb0b09546