### PR TITLE
Add indexes to items table to speed up homepage queries

### DIFF
--- a/core/DB.php
+++ b/core/DB.php
@@ -104,6 +104,7 @@ class DB
         );');
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_item ON attachments(item_id)');
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_step ON attachments(step_id)');
+        self::ensureItemIndexes($pdo);
         self::ensurePreviousCategoryColumn($pdo);
     }
 
@@ -120,6 +121,13 @@ class DB
         if (!$hasColumn) {
             $pdo->exec('ALTER TABLE items ADD COLUMN previous_category_id INTEGER');
         }
+    }
+
+    private static function ensureItemIndexes(PDO $pdo): void
+    {
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_done_order ON items(done, order_index, updated_at DESC, id DESC)');
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_category_order ON items(category_id, order_index, updated_at DESC, id DESC)');
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_done_category ON items(done, category_id)');
     }
 
     private static function seedDefaultCategories(PDO $pdo): void

--- a/memo.php
+++ b/memo.php
@@ -358,6 +358,7 @@ function memo_ensure_base_tables(PDO $pdo): void {
   );');
   $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_item ON attachments(item_id)');
   $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_step ON attachments(step_id)');
+  memo_ensure_item_indexes($pdo);
 
   $columns = $pdo->query('PRAGMA table_info(items)')->fetchAll(PDO::FETCH_ASSOC);
   $hasColumn = false;
@@ -370,6 +371,12 @@ function memo_ensure_base_tables(PDO $pdo): void {
   if (!$hasColumn) {
     $pdo->exec('ALTER TABLE items ADD COLUMN previous_category_id INTEGER');
   }
+}
+
+function memo_ensure_item_indexes(PDO $pdo): void {
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_done_order ON items(done, order_index, updated_at DESC, id DESC)');
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_category_order ON items(category_id, order_index, updated_at DESC, id DESC)');
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_done_category ON items(done, category_id)');
 }
 
 function memo_seed_default_categories(PDO $pdo): void {


### PR DESCRIPTION
## Summary
- add covering indexes for items table filters and ordering used on the homepage
- ensure both database bootstrap paths create the new indexes during initialization

## Testing
- php -l core/DB.php
- php -l memo.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68e8f2fed9d08328b23709bcfd4d236c