### PR TITLE
优化 items 表查询索引提升首页性能

### DIFF
--- a/core/DB.php
+++ b/core/DB.php
@@ -7,7 +7,7 @@ use RuntimeException;
 
 class DB
 {
-    private const SCHEMA_VERSION = 2;
+    private const SCHEMA_VERSION = 3;
 
     private static ?PDO $pdo = null;
 
@@ -48,8 +48,17 @@ class DB
             self::ensureBaseTables($pdo);
         }
 
-        if ($currentVersion < self::SCHEMA_VERSION) {
+        if ($currentVersion < 2) {
             self::ensureMindmapSchema($pdo);
+            self::setUserVersion($pdo, 2);
+            $currentVersion = 2;
+        } else {
+            self::ensureMindmapSchema($pdo);
+        }
+
+        self::ensureItemIndexes($pdo);
+
+        if ($currentVersion < self::SCHEMA_VERSION) {
             self::setUserVersion($pdo, self::SCHEMA_VERSION);
         }
     }
@@ -105,6 +114,7 @@ class DB
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_item ON attachments(item_id)');
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_step ON attachments(step_id)');
         self::ensurePreviousCategoryColumn($pdo);
+        self::ensureItemIndexes($pdo);
     }
 
     private static function ensurePreviousCategoryColumn(PDO $pdo): void
@@ -120,6 +130,12 @@ class DB
         if (!$hasColumn) {
             $pdo->exec('ALTER TABLE items ADD COLUMN previous_category_id INTEGER');
         }
+    }
+
+    private static function ensureItemIndexes(PDO $pdo): void
+    {
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_done_order ON items(done, order_index, updated_at DESC, id DESC)');
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_category_order ON items(category_id, done, order_index, updated_at DESC, id DESC)');
     }
 
     private static function seedDefaultCategories(PDO $pdo): void

--- a/memo.php
+++ b/memo.php
@@ -305,8 +305,17 @@ function memo_run_legacy_migrations(PDO $pdo, bool $init): void {
   if ($currentVersion < 2) {
     memo_ensure_mindmap_tables($pdo, true);
     memo_set_user_version($pdo, 2);
+    $currentVersion = 2;
   } elseif ($init) {
     memo_ensure_mindmap_tables($pdo, false);
+  } else {
+    memo_ensure_mindmap_tables($pdo, false);
+  }
+
+  memo_ensure_item_indexes($pdo);
+
+  if ($currentVersion < 3) {
+    memo_set_user_version($pdo, 3);
   }
 }
 
@@ -370,6 +379,13 @@ function memo_ensure_base_tables(PDO $pdo): void {
   if (!$hasColumn) {
     $pdo->exec('ALTER TABLE items ADD COLUMN previous_category_id INTEGER');
   }
+
+  memo_ensure_item_indexes($pdo);
+}
+
+function memo_ensure_item_indexes(PDO $pdo): void {
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_done_order ON items(done, order_index, updated_at DESC, id DESC)');
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_items_category_order ON items(category_id, done, order_index, updated_at DESC, id DESC)');
 }
 
 function memo_seed_default_categories(PDO $pdo): void {


### PR DESCRIPTION
## Summary
- bump the SQLite schema version to 3 and add item index creation to the migration flow
- ensure new and existing databases create composite indexes for done/order and category/order filtering
- expose the same index setup paths in the legacy memo runner to keep both entry points consistent

## Testing
- php -l core/DB.php
- php -l memo.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68e8f2fed9d08328b23709bcfd4d236c