### PR TITLE
Implement paginated memo list and optimize mindmap asset cleanup

### DIFF
--- a/config/security.php
+++ b/config/security.php
@@ -24,8 +24,8 @@ return [
         'directives' => [
             'default-src' => "'self' cdn.jsdelivr.net",
             'img-src' => "'self' data: blob:",
-            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net fonts.googleapis.com",
-            'font-src' => "fonts.gstatic.com",
+            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
+            'font-src' => "'self' data:",
             'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
             'base-uri' => "'self'",
             'form-action' => "'self'",

--- a/core/DB.php
+++ b/core/DB.php
@@ -111,6 +111,8 @@ class DB
             FOREIGN KEY(item_id) REFERENCES items(id) ON DELETE CASCADE,
             FOREIGN KEY(step_id) REFERENCES steps(id) ON DELETE CASCADE
         );');
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_steps_item_order ON steps(item_id, order_index, id)');
+        $pdo->exec('CREATE INDEX IF NOT EXISTS idx_steps_item_created ON steps(item_id, created_at, id)');
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_item ON attachments(item_id)');
         $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_step ON attachments(step_id)');
         self::ensurePreviousCategoryColumn($pdo);

--- a/memo.php
+++ b/memo.php
@@ -144,7 +144,7 @@ function memo_apply_default_security_headers(): void {
   header('X-Frame-Options: SAMEORIGIN');
   header('Referrer-Policy: strict-origin-when-cross-origin');
   header('X-Content-Type-Options: nosniff');
-  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net fonts.googleapis.com; font-src fonts.gstatic.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
+  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' data:; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
   MemoEnvironment::markSecurityHeadersApplied();
 }
 
@@ -365,6 +365,8 @@ function memo_ensure_base_tables(PDO $pdo): void {
     FOREIGN KEY(item_id) REFERENCES items(id) ON DELETE CASCADE,
     FOREIGN KEY(step_id) REFERENCES steps(id) ON DELETE CASCADE
   );');
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_steps_item_order ON steps(item_id, order_index, id)');
+  $pdo->exec('CREATE INDEX IF NOT EXISTS idx_steps_item_created ON steps(item_id, created_at, id)');
   $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_item ON attachments(item_id)');
   $pdo->exec('CREATE INDEX IF NOT EXISTS idx_att_step ON attachments(step_id)');
 
@@ -597,11 +599,28 @@ function mindmap_assets_for_session(string $session_key): array {
   return $st->fetchAll();
 }
 
-function delete_mindmap_asset(int $id): void {
-  $asset=get_mindmap_asset($id);
+function mindmap_assets_by_ids(array $ids): array {
+  $ids=array_values(array_unique(array_filter(array_map('intval',$ids),fn($v)=>$v>0)));
+  if(!$ids){ return []; }
+  $pdo=db();
+  $placeholders=implode(',',array_fill(0,count($ids),'?'));
+  $st=$pdo->prepare("SELECT * FROM mindmap_assets WHERE id IN ($placeholders)");
+  $st->execute($ids);
+  $map=[];
+  foreach($st->fetchAll() as $row){
+    if(isset($row['id'])){ $map[(int)$row['id']]=$row; }
+  }
+  return $map;
+}
+
+function delete_mindmap_asset(int $id, ?array $asset = null): void {
+  $asset=$asset ?? get_mindmap_asset($id);
   if(!$asset) return;
-  $path=memo_upload_dir().DIRECTORY_SEPARATOR.$asset['stored_name'];
-  if(is_file($path)) @unlink($path);
+  $storedName=(string)($asset['stored_name'] ?? '');
+  if($storedName!==''){
+    $path=memo_upload_dir().DIRECTORY_SEPARATOR.$storedName;
+    if(is_file($path)) @unlink($path);
+  }
   $pdo=db();
   $pdo->prepare('DELETE FROM mindmap_assets WHERE id=?')->execute([$id]);
 }
@@ -628,11 +647,11 @@ function cleanup_stale_mindmap_session_assets(int $max_age_seconds = 172800, int
   $batch_limit = max(1, $batch_limit);
   $threshold = now() - $max_age_seconds;
   $pdo = db();
-  $st = $pdo->prepare("SELECT id FROM mindmap_assets WHERE (mindmap_id IS NULL OR mindmap_id=0) AND session_key IS NOT NULL AND session_key<>'' AND (created_at IS NULL OR created_at < ?) LIMIT ?");
+  $st = $pdo->prepare("SELECT id, stored_name FROM mindmap_assets WHERE (mindmap_id IS NULL OR mindmap_id=0) AND session_key IS NOT NULL AND session_key<>'' AND (created_at IS NULL OR created_at < ?) LIMIT ?");
   $st->execute([$threshold, $batch_limit]);
   foreach($st->fetchAll() as $row){
     $assetId = isset($row['id']) ? (int)$row['id'] : 0;
-    if($assetId>0){ delete_mindmap_asset($assetId); }
+    if($assetId>0){ delete_mindmap_asset($assetId,$row); }
   }
 }
 
@@ -643,12 +662,12 @@ function prune_mindmap_assets(int $map_id, array $keep_ids): void {
   $params=$ids;
   array_unshift($params,$map_id);
   $sql=$ids?
-    "SELECT id FROM mindmap_assets WHERE mindmap_id=? AND id NOT IN ($placeholders)" :
-    "SELECT id FROM mindmap_assets WHERE mindmap_id=?";
+    "SELECT id, stored_name FROM mindmap_assets WHERE mindmap_id=? AND id NOT IN ($placeholders)" :
+    "SELECT id, stored_name FROM mindmap_assets WHERE mindmap_id=?";
   $st=$pdo->prepare($sql);
   $st->execute($params);
   $rows=$st->fetchAll();
-  foreach($rows as $row){ delete_mindmap_asset((int)$row['id']); }
+  foreach($rows as $row){ delete_mindmap_asset((int)$row['id'],$row); }
 }
 
 // —— 思维导图 ——
@@ -684,7 +703,7 @@ function update_mindmap(int $id, string $title, string $content): array {
 function delete_mindmap(int $id): void {
   $pdo=db();
   $assets=mindmap_assets_for_map($id);
-  foreach($assets as $asset){ delete_mindmap_asset((int)$asset['id']); }
+  foreach($assets as $asset){ delete_mindmap_asset((int)$asset['id'],$asset); }
   $pdo->prepare('DELETE FROM mindmaps WHERE id=?')->execute([$id]);
 }
 
@@ -880,11 +899,11 @@ function sync_mindmap_assets(int $map_id, array $asset_refs, string $session_key
     $params=$ids;
     array_unshift($params,$session_key);
     $sql=$ids?
-      "SELECT id FROM mindmap_assets WHERE session_key=? AND id NOT IN ($placeholders)" :
-      "SELECT id FROM mindmap_assets WHERE session_key=?";
+      "SELECT id, stored_name FROM mindmap_assets WHERE session_key=? AND id NOT IN ($placeholders)" :
+      "SELECT id, stored_name FROM mindmap_assets WHERE session_key=?";
     $st=$pdo->prepare($sql);
     $st->execute($params);
-    foreach($st->fetchAll() as $row){ delete_mindmap_asset((int)$row['id']); }
+    foreach($st->fetchAll() as $row){ delete_mindmap_asset((int)$row['id'],$row); }
   }
 }
 
@@ -1435,9 +1454,11 @@ if (is_post()) {
         }
         $ids=array_values(array_unique(array_filter($ids,fn($v)=>$v>0)));
         $deleted=0;
+        $assetMap=$ids?mindmap_assets_by_ids($ids):[];
         foreach($ids as $assetId){
-          delete_mindmap_asset($assetId);
-          $deleted++;
+          $asset=$assetMap[$assetId] ?? null;
+          delete_mindmap_asset($assetId,$asset);
+          if($asset){ $deleted++; }
         }
         if(is_ajax()){
           header('Content-Type: application/json');
@@ -1572,6 +1593,20 @@ $cat=$_GET['cat'] ?? 'all';
 $q=trim((string)($_GET['q'] ?? ''));
 $mindmap_total = (int)($stats['mindmap_total'] ?? 0);
 $isMindmapCategory = $cat === 'mindmaps';
+$page=isset($_GET['page']) && ctype_digit((string)$_GET['page']) ? max(1,(int)$_GET['page']) : 1;
+$pageSize=20;
+$pagination=[
+  'page'=>$page,
+  'per_page'=>$pageSize,
+  'total'=>0,
+  'pages'=>1,
+  'has_prev'=>false,
+  'has_next'=>false,
+  'prev_page'=>null,
+  'next_page'=>null,
+  'from'=>0,
+  'to'=>0,
+];
 $items=[];
 $mindmapsAll=[];
 if($isMindmapCategory){
@@ -1587,10 +1622,44 @@ if($isMindmapCategory){
   }
   if($cat!=='all' && ctype_digit((string)$cat)){ $where[]='category_id = :cat'; $params[':cat']=(int)$cat; }
   if($q!==''){ $where[]='(title LIKE :q OR description LIKE :q)'; $params[':q']='%'.$q.'%'; }
+  $countSql='SELECT COUNT(*) FROM items';
+  if($where) $countSql.=' WHERE '.implode(' AND ',$where);
+  $stCount=$pdo->prepare($countSql);
+  $stCount->execute($params);
+  $totalRows=(int)$stCount->fetchColumn();
+  $totalPages=$totalRows>0 ? (int)ceil($totalRows/$pageSize) : 1;
+  if($totalPages<1){ $totalPages=1; }
+  if($totalRows===0){
+    $page=1;
+    $offset=0;
+  } else {
+    if($page>$totalPages){ $page=$totalPages; }
+    $offset=($page-1)*$pageSize;
+  }
   $sql='SELECT * FROM items';
   if($where) $sql.=' WHERE '.implode(' AND ',$where);
-  $sql.=' ORDER BY order_index ASC, updated_at DESC, id DESC';
-  $st=$pdo->prepare($sql); $st->execute($params); $items=$st->fetchAll();
+  $sql.=' ORDER BY order_index ASC, updated_at DESC, id DESC LIMIT :limit OFFSET :offset';
+  $st=$pdo->prepare($sql);
+  foreach($params as $key=>$value){
+    $type=is_int($value)?\PDO::PARAM_INT:\PDO::PARAM_STR;
+    $st->bindValue($key,$value,$type);
+  }
+  $st->bindValue(':limit',$pageSize,\PDO::PARAM_INT);
+  $st->bindValue(':offset',$offset,\PDO::PARAM_INT);
+  $st->execute();
+  $items=$st->fetchAll();
+  $pagination=[
+    'page'=>$page,
+    'per_page'=>$pageSize,
+    'total'=>$totalRows,
+    'pages'=>$totalRows>0 ? $totalPages : 1,
+    'has_prev'=>$page>1,
+    'has_next'=>$totalRows>0 && $page<$totalPages,
+    'prev_page'=>$page>1 ? $page-1 : null,
+    'next_page'=>$totalRows>0 && $page<$totalPages ? $page+1 : null,
+    'from'=>$totalRows>0 ? $offset+1 : 0,
+    'to'=>$totalRows>0 ? min($offset+count($items),$totalRows) : 0,
+  ];
 }
 $all_total = (int)($stats['active_total'] ?? 0);
 $categoryNames=[];

--- a/resources/views/memo/index.phtml
+++ b/resources/views/memo/index.phtml
@@ -6,9 +6,6 @@
 <title>自适应备忘录 · 单文件</title>
 <meta name="color-scheme" content="dark"/>
 <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
 <style>
   :root{
     --bg-void:#0A0C0E;
@@ -44,9 +41,11 @@
     --shadow:0 24px 60px rgba(0,0,0,.72);
     --grid-size:72px;
     --transition:300ms cubic-bezier(.22,.61,.36,1);
+    --font-sans:'Inter','Source Han Sans','Noto Sans SC','PingFang SC','Microsoft YaHei','Helvetica Neue',Arial,sans-serif;
+    --font-serif:'Noto Serif SC','Source Han Serif SC','Songti SC','STSong','serif';
   }
   *,*::before,*::after{box-sizing:border-box}
-  html,body{margin:0;min-height:100vh;background:var(--bg-void);color:var(--text-strong);font:16px/1.65 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow-x:hidden}
+  html,body{margin:0;min-height:100vh;background:var(--bg-void);color:var(--text-strong);font:16px/1.65 var(--font-sans);letter-spacing:.01em;position:relative;overflow-x:hidden}
   body{--item-padding:18px 16px;--item-gap:12px;--item-radius:18px;--item-line:36px;--item-desc-lines:3;--item-grid-gap:20px;}
   body[data-density='compact']{--item-padding:14px 14px;--item-gap:8px;--item-radius:16px;--item-line:28px;--item-desc-lines:2;--item-grid-gap:16px;}
 
@@ -72,15 +71,15 @@
   .brand{display:flex;gap:12px;align-items:center;margin-bottom:18px;text-transform:uppercase;letter-spacing:.16em;color:var(--text-muted)}
   .brand .logo{width:34px;height:34px;border-radius:12px;background:radial-gradient(circle at 30% 30%,rgba(227,198,139,.85),rgba(227,198,139,.22));box-shadow:0 0 14px rgba(227,198,139,.45),0 0 32px rgba(227,198,139,.28);position:relative;overflow:hidden}
   .brand .logo::after{content:"";position:absolute;inset:6px;border-radius:10px;border:1px solid rgba(201,168,106,.38);box-shadow:0 0 16px rgba(227,198,139,.3);opacity:.85}
-  .brand h1{font:600 16px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);text-shadow:0 0 18px rgba(227,198,139,.25)}
+  .brand h1{font:600 16px/1.2 var(--font-serif);color:var(--gold-400);text-shadow:0 0 18px rgba(227,198,139,.25)}
   .controls{display:flex;gap:10px;flex-wrap:wrap;margin:10px 0 18px}
   .dropdown{position:relative;display:inline-flex}
   .dropdown-toggle{width:100%}
   .dropdown-menu{position:absolute;top:calc(100% + 6px);left:0;min-width:100%;display:none;flex-direction:column;gap:6px;padding:10px;border-radius:14px;border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.94);box-shadow:0 16px 36px rgba(0,0,0,.45);z-index:40}
   .dropdown-menu[data-open="true"]{display:flex}
-  .dropdown-menu a{display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:10px;color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;text-decoration:none;transition:background var(--transition),color var(--transition)}
+  .dropdown-menu a{display:flex;align-items:center;gap:8px;padding:8px 12px;border-radius:10px;color:var(--text-strong);font:600 12px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;text-decoration:none;transition:background var(--transition),color var(--transition)}
   .dropdown-menu a:hover{background:rgba(201,168,106,.12);color:var(--gold-400)}
-  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 16px;border-radius:14px;border:1px solid transparent;background:transparent;color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:none;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),background var(--transition),color var(--transition);cursor:pointer}
+  .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;gap:8px;padding:10px 16px;border-radius:14px;border:1px solid transparent;background:transparent;color:var(--text-strong);font:600 12px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;text-decoration:none;box-shadow:none;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),background var(--transition),color var(--transition);cursor:pointer}
   .btn::before{content:"";position:absolute;inset:0;border-radius:inherit;box-shadow:inset 0 0 0 1px rgba(227,198,139,.08);opacity:0;transition:opacity var(--transition)}
   .btn:hover::before{opacity:1}
   .btn-primary,.btn.acc{background:linear-gradient(135deg,var(--gold-500),var(--gold-600));color:#1b1306;border-color:rgba(142,107,61,.75);box-shadow:0 16px 34px rgba(227,198,139,.24),0 0 24px rgba(227,198,139,.18)}
@@ -97,7 +96,7 @@
   .btn-label{display:inline-flex}
   .btn:active{transform:translateY(0);box-shadow:none}
 
-  .section-title{font:600 12px/1 'Cinzel','Noto Serif SC',serif;text-transform:uppercase;letter-spacing:.24em;color:var(--gold-400);margin:14px 0 8px;text-shadow:0 0 14px rgba(227,198,139,.24)}
+  .section-title{font:600 12px/1 var(--font-serif);text-transform:uppercase;letter-spacing:.24em;color:var(--gold-400);margin:14px 0 8px;text-shadow:0 0 14px rgba(227,198,139,.24)}
   .cat-list{display:flex;flex-direction:column;gap:8px}
   .cat{position:relative;display:flex;align-items:center;justify-content:space-between;gap:10px;padding:12px 14px;border-radius:14px;background:linear-gradient(140deg,rgba(15,19,22,.88),rgba(10,12,14,.88));border:1px solid var(--border-soft);box-shadow:inset 0 0 0 1px rgba(201,168,106,.06);transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition)}
   .cat::before{content:"";position:absolute;inset:4px;border-radius:12px;border:1px dashed rgba(201,168,106,.18);opacity:0;transition:opacity var(--transition)}
@@ -105,7 +104,7 @@
   .cat:hover::before{opacity:1}
   .cat.active{border-color:var(--glow);box-shadow:0 0 18px rgba(201,168,106,.3)}
   .cat .name{flex:1;display:block;font-weight:600;color:var(--text-strong);text-shadow:0 0 8px rgba(201,168,106,.18)}
-  .cat .count{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;color:var(--text-dim);letter-spacing:.14em;text-transform:uppercase}
+  .cat .count{font:600 12px/1 var(--font-sans);color:var(--text-dim);letter-spacing:.14em;text-transform:uppercase}
   .footer{margin-top:18px;color:var(--text-dim);font-size:12px;line-height:1.8;text-shadow:0 0 10px rgba(201,168,106,.15)}
   .main{padding:24px 20px 40px;margin-left:var(--sidebar-width);background:linear-gradient(160deg,rgba(12,14,18,.82),rgba(10,12,14,.85));backdrop-filter:blur(14px) saturate(160%);position:relative;min-height:100vh;flex:1 1 auto;min-width:0;width:min(100%,calc(100vw - var(--sidebar-width)));max-width:calc(100vw - var(--sidebar-width));box-sizing:border-box}
   .main::before{content:"";position:absolute;inset:0;border-left:1px solid rgba(201,168,106,.12);border-top:1px solid rgba(201,168,106,.06);pointer-events:none;box-shadow:inset 0 0 0 1px rgba(201,168,106,.04)}
@@ -113,7 +112,7 @@
   .search{flex:1 1 260px;display:flex;align-items:center;gap:10px;background:linear-gradient(135deg,rgba(15,19,22,.9),rgba(10,12,14,.88));border:1px solid rgba(201,168,106,.32);border-radius:16px;padding:10px 14px;box-shadow:inset 0 0 28px rgba(201,168,106,.08)}
   .search input{all:unset;flex:1;color:var(--text-strong);font-size:15px;letter-spacing:.06em}
   .search input::placeholder{color:var(--text-dim)}
-  .search button{padding:8px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.42);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;text-transform:none;letter-spacing:.08em;cursor:pointer;transition:background var(--transition),box-shadow var(--transition),border-color var(--transition)}
+  .search button{padding:8px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.42);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 11px/1 var(--font-sans);text-transform:none;letter-spacing:.08em;cursor:pointer;transition:background var(--transition),box-shadow var(--transition),border-color var(--transition)}
   .search button:lang(en){text-transform:uppercase;letter-spacing:.18em}
   .search button:hover{background:rgba(201,168,106,.2);border-color:rgba(201,168,106,.6);box-shadow:0 0 18px rgba(227,198,139,.22)}
   .actions-row{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
@@ -137,14 +136,14 @@
   .item-title{font-weight:600;font-size:16px;line-height:var(--item-line);letter-spacing:.2px;color:var(--text-strong);text-shadow:0 0 14px rgba(227,198,139,.16);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;word-break:break-word}
   .item.done .item-title,.item.done .item-desc,.item.done .tinyline{text-decoration:line-through;color:rgba(227,198,139,.75)}
   .item-desc{color:var(--text-muted);white-space:pre-wrap;display:-webkit-box;-webkit-line-clamp:var(--item-desc-lines);-webkit-box-orient:vertical;overflow:hidden;word-break:break-word;font-size:13px;line-height:1.6;opacity:.88}
-  .badge{display:inline-flex;align-items:center;gap:6px;font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em;padding:4px 10px;border-radius:999px;border:1px solid rgba(230,192,137,.32);background:rgba(230,192,137,.08);color:var(--text-muted);box-shadow:inset 0 0 12px rgba(230,192,137,.05)}
+  .badge{display:inline-flex;align-items:center;gap:6px;font:600 11px/1 var(--font-sans);letter-spacing:.1em;padding:4px 10px;border-radius:999px;border:1px solid rgba(230,192,137,.32);background:rgba(230,192,137,.08);color:var(--text-muted);box-shadow:inset 0 0 12px rgba(230,192,137,.05)}
   .badge:lang(en){text-transform:uppercase;letter-spacing:.22em}
   .attachment-badge{background:rgba(75,195,209,.14);border-color:rgba(75,195,209,.38);color:#9fe8f1}
   .item-meta{display:flex;justify-content:space-between;align-items:flex-end;gap:12px;margin-top:6px;font-size:12px;opacity:.75}
   .item-meta .meta-left{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
   .item-meta .meta-right{margin-left:auto;text-align:right;display:flex;justify-content:flex-end;min-width:130px}
-  .item-meta .item-time{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;color:var(--text-dim);white-space:nowrap}
-  .kbd{font:600 12px/1 'Inter','Noto Sans SC',sans-serif;padding:2px 6px;border:1px dashed rgba(201,168,106,.35);border-radius:6px;background:rgba(15,19,22,.82);color:var(--text-dim);text-transform:uppercase;letter-spacing:.16em;box-shadow:0 0 12px rgba(201,168,106,.12)}
+  .item-meta .item-time{font:600 12px/1 var(--font-sans);letter-spacing:.12em;color:var(--text-dim);white-space:nowrap}
+  .kbd{font:600 12px/1 var(--font-sans);padding:2px 6px;border:1px dashed rgba(201,168,106,.35);border-radius:6px;background:rgba(15,19,22,.82);color:var(--text-dim);text-transform:uppercase;letter-spacing:.16em;box-shadow:0 0 12px rgba(201,168,106,.12)}
   mark{background:rgba(75,195,209,.2);color:inherit;padding:0 2px;border-radius:4px}
   .tinyline{position:relative;margin-left:12px;padding-left:28px;color:var(--text-muted)}
   .tinyline::before{content:"";position:absolute;left:12px;top:4px;bottom:4px;width:2px;border-radius:999px;background:linear-gradient(to bottom,rgba(201,168,106,.65),rgba(201,168,106,.18));box-shadow:0 0 18px rgba(227,198,139,.25),0 0 24px rgba(201,168,106,.22)}
@@ -160,44 +159,50 @@
   }
   .tlrow.done .dot{background:radial-gradient(circle at 50% 50%,rgba(198,250,222,.95),rgba(56,189,148,.85));box-shadow:0 0 16px rgba(56,189,148,.6),0 0 28px rgba(16,185,129,.45);filter:none;animation:none}
   .tlrow.done .dot::after{border-color:rgba(56,189,148,.45);opacity:.9;box-shadow:0 0 18px rgba(16,185,129,.35)}
-  .ts{color:var(--text-dim);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;margin-left:6px;letter-spacing:.12em;text-transform:uppercase}
+  .ts{color:var(--text-dim);font:600 12px/1 var(--font-sans);margin-left:6px;letter-spacing:.12em;text-transform:uppercase}
   .item-actions{display:flex;gap:8px;justify-content:flex-end;align-items:center;flex-wrap:wrap}
   .item-actions form{margin:0}
-  .item-actions .tip{margin-right:auto;color:var(--text-dim);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em;text-transform:none}
+  .item-actions .tip{margin-right:auto;color:var(--text-dim);font:600 11px/1 var(--font-sans);letter-spacing:.1em;text-transform:none}
   .item-actions .tip:lang(en){letter-spacing:.2em;text-transform:uppercase}
   .item-actions .status-tip{color:var(--gold-400)}
   .item-actions .note-tip{margin-right:0}
   .move-controls{display:flex;gap:6px}
   .move-controls.mobile{display:none}
+  .pagination{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:12px;margin:24px 0 18px;padding:0 4px;color:var(--text-muted)}
+  .pagination .page-info{font:600 12px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase}
+  .pagination .page-links{display:flex;gap:8px;flex-wrap:wrap}
+  .pagination .page-btn{display:inline-flex;align-items:center;justify-content:center;padding:8px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.72);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.1em;text-transform:uppercase;text-decoration:none;transition:background var(--transition),box-shadow var(--transition),border-color var(--transition)}
+  .pagination .page-btn:hover{background:rgba(201,168,106,.16);border-color:rgba(201,168,106,.45)}
+  .pagination .page-btn.disabled{opacity:.4;pointer-events:none}
   .err{background:rgba(209,75,75,.16);color:rgba(255,214,214,.92);border:1px solid rgba(209,75,75,.45);border-radius:16px;box-shadow:0 0 20px rgba(209,75,75,.24);padding:10px 14px}
-  .flash-message{margin-bottom:12px;font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase}
-  .shortcuts{margin-top:14px;color:var(--text-dim);font:600 11px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase}
+  .flash-message{margin-bottom:12px;font:600 12px/1.4 var(--font-sans);letter-spacing:.16em;text-transform:uppercase}
+  .shortcuts{margin-top:14px;color:var(--text-dim);font:600 11px/1.2 var(--font-sans);letter-spacing:.18em;text-transform:uppercase}
   .toast-container{position:fixed;left:50%;bottom:32px;transform:translateX(-50%);display:grid;gap:12px;z-index:140;pointer-events:none}
   .toast{display:flex;gap:12px;align-items:center;padding:14px 18px;border-radius:14px;background:rgba(15,19,22,.92);border:1px solid rgba(230,192,137,.32);box-shadow:0 20px 48px rgba(0,0,0,.55);color:var(--text-strong);min-width:260px;pointer-events:auto}
-  .toast-message{font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted)}
+  .toast-message{font:600 12px/1.4 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;color:var(--text-muted)}
   .modal-backdrop{position:fixed;inset:0;background:rgba(3,6,8,.76);backdrop-filter:blur(16px);display:none;align-items:center;justify-content:center;padding:16px;z-index:120}
   .modal-panel{background:linear-gradient(150deg,rgba(15,19,22,.92),rgba(10,12,14,.94));border:1px solid rgba(201,168,106,.32);border-radius:22px;box-shadow:0 32px 64px rgba(0,0,0,.68),0 0 34px rgba(201,168,106,.16);padding:18px;max-width:520px;width:100%;display:grid;gap:14px;position:relative}
   .modal-panel::before{content:"";position:absolute;inset:10px;border-radius:18px;border:1px dashed rgba(201,168,106,.24);opacity:.85;pointer-events:none;box-shadow:inset 0 0 22px rgba(201,168,106,.08)}
   .modal-header{display:flex;justify-content:space-between;align-items:center;gap:12px}
-  .modal-title{font:600 16px/1 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.18em;text-transform:uppercase;text-shadow:0 0 18px rgba(227,198,139,.24)}
+  .modal-title{font:600 16px/1 var(--font-serif);color:var(--gold-400);letter-spacing:.18em;text-transform:uppercase;text-shadow:0 0 18px rgba(227,198,139,.24)}
   .modal-list{display:grid;gap:10px}
   .modal-form{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
   .modal-input{flex:1;min-width:200px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.86);color:var(--text-strong);letter-spacing:.08em}
   .modal-input::placeholder{color:var(--text-dim)}
-  .modal-count{color:var(--text-dim);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase}
+  .modal-count{color:var(--text-dim);font:600 12px/1 var(--font-sans);letter-spacing:.16em;text-transform:uppercase}
   .mindmap-view{display:grid;gap:24px}
   .mindmap-header{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;flex-wrap:wrap}
-  .mindmap-header h2{margin:0;font:600 20px/1 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase;text-shadow:0 0 20px rgba(227,198,139,.24)}
-  .mindmap-header-meta{margin-top:6px;color:var(--text-muted);font:13px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
+  .mindmap-header h2{margin:0;font:600 20px/1 var(--font-serif);color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase;text-shadow:0 0 20px rgba(227,198,139,.24)}
+  .mindmap-header-meta{margin-top:6px;color:var(--text-muted);font:13px/1.6 var(--font-sans);letter-spacing:.1em}
   .mindmap-actions{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
   .mindmap-search{display:flex;align-items:center;gap:10px;padding:12px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.28);background:rgba(15,19,22,.82);box-shadow:inset 0 0 22px rgba(0,0,0,.4);max-width:460px}
-  .mindmap-search input{flex:1;border:0;background:transparent;color:var(--text-strong);font:15px/1.4 'Inter','Noto Sans SC',sans-serif;outline:none}
+  .mindmap-search input{flex:1;border:0;background:transparent;color:var(--text-strong);font:15px/1.4 var(--font-sans);outline:none}
   .mindmap-search span{font-size:18px}
   .mindmap-grid{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(min(320px,100%),1fr));justify-content:center}
   .mindmap-card{position:relative;display:flex;flex-direction:column;gap:14px;min-height:240px;min-width:0;width:100%;padding:20px;border-radius:20px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.94));border:1px solid rgba(201,168,106,.28);box-shadow:0 20px 48px rgba(0,0,0,.55);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition)}
   .mindmap-card:hover{transform:translateY(-4px);border-color:rgba(201,168,106,.45);box-shadow:0 24px 60px rgba(0,0,0,.6)}
-  .mindmap-card h3{margin:0;font:600 18px/1.4 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase;overflow-wrap:anywhere;hyphens:auto}
-  .mindmap-card-meta{color:var(--text-muted);font:12px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+  .mindmap-card h3{margin:0;font:600 18px/1.4 var(--font-serif);color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase;overflow-wrap:anywhere;hyphens:auto}
+  .mindmap-card-meta{color:var(--text-muted);font:12px/1.6 var(--font-sans);letter-spacing:.08em}
   .mindmap-card pre{margin:0;background:rgba(15,19,22,.85);border:1px solid rgba(201,168,106,.24);padding:12px;border-radius:14px;max-height:150px;overflow:auto;font:12px/1.6 'JetBrains Mono','Fira Code',monospace;color:var(--text-strong);box-shadow:inset 0 0 18px rgba(0,0,0,.45);white-space:pre-wrap;word-break:break-word;overflow-wrap:anywhere}
   .mindmap-card-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:auto}
   .mindmap-empty{padding:40px;border:1px dashed rgba(201,168,106,.32);border-radius:20px;text-align:center;color:var(--text-muted);background:rgba(15,19,22,.82)}
@@ -206,60 +211,60 @@
   .mindmap-import-backdrop[data-open="true"]{display:flex}
   .mindmap-import-panel{background:linear-gradient(160deg,rgba(21,26,30,.92),rgba(12,16,18,.94));border:1px solid rgba(201,168,106,.34);border-radius:24px;box-shadow:0 32px 64px rgba(0,0,0,.68),0 0 30px rgba(227,198,139,.18);padding:24px;max-width:420px;width:100%;display:grid;gap:16px;position:relative}
   .mindmap-import-panel::before{content:"";position:absolute;inset:12px;border-radius:18px;border:1px dashed rgba(201,168,106,.24);opacity:.7;pointer-events:none}
-  .mindmap-import-panel h2{margin:0;font:600 18px/1.3 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.14em;text-transform:uppercase;text-align:center}
-  .mindmap-import-panel p{margin:0;color:var(--text-dim);font:12px/1.6 'Inter','Noto Sans SC',sans-serif;text-align:center;letter-spacing:.08em}
+  .mindmap-import-panel h2{margin:0;font:600 18px/1.3 var(--font-serif);color:var(--gold-400);letter-spacing:.14em;text-transform:uppercase;text-align:center}
+  .mindmap-import-panel p{margin:0;color:var(--text-dim);font:12px/1.6 var(--font-sans);text-align:center;letter-spacing:.08em}
   .mindmap-import-panel .mode-buttons{display:grid;gap:10px}
-  .mindmap-import-panel .mode-buttons button{padding:12px 16px;border-radius:16px;border:1px solid rgba(227,198,139,.6);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.58));color:#1b1306;font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition)}
+  .mindmap-import-panel .mode-buttons button{padding:12px 16px;border-radius:16px;border:1px solid rgba(227,198,139,.6);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.58));color:#1b1306;font:600 12px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition)}
   .mindmap-import-panel .mode-buttons button:hover{transform:translateY(-2px);box-shadow:0 18px 36px rgba(227,198,139,.3),0 0 28px rgba(227,198,139,.24)}
   .mindmap-import-panel .mode-buttons button:disabled{opacity:.45;cursor:not-allowed;transform:none;box-shadow:none}
-  .mindmap-import-panel label{display:flex;flex-direction:column;gap:6px;font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;color:var(--text-muted)}
-  .mindmap-import-panel select{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.86);color:var(--text-strong);font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif}
-  .mindmap-import-panel .import-tip{color:var(--text-dim);font:12px/1.5 'Inter','Noto Sans SC',sans-serif;text-align:left}
+  .mindmap-import-panel label{display:flex;flex-direction:column;gap:6px;font:600 12px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;color:var(--text-muted)}
+  .mindmap-import-panel select{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.86);color:var(--text-strong);font:600 13px/1.2 var(--font-sans)}
+  .mindmap-import-panel .import-tip{color:var(--text-dim);font:12px/1.5 var(--font-sans);text-align:left}
   .mindmap-import-panel .actions{display:flex;justify-content:flex-end;gap:10px}
-  .mindmap-import-panel .actions button{padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
+  .mindmap-import-panel .actions button{padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
   .mindmap-import-panel .actions button:hover{transform:translateY(-2px);box-shadow:0 12px 26px rgba(227,198,139,.22)}
   .attachment-preview-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(5,7,10,.78);backdrop-filter:blur(18px);z-index:260}
   .attachment-preview-backdrop[data-open="true"]{display:flex}
   .attachment-preview-panel{width:min(960px,calc(100vw - 32px));max-height:min(90vh,96svh);background:linear-gradient(165deg,rgba(21,26,30,.95),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.34);border-radius:24px;box-shadow:0 32px 64px rgba(0,0,0,.7),0 0 34px rgba(227,198,139,.2);padding:20px;display:flex;flex-direction:column;gap:16px;position:relative}
   .attachment-preview-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-  .attachment-preview-title{margin:0;font:600 18px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
-  .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
+  .attachment-preview-title{margin:0;font:600 18px/1.2 var(--font-serif);color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
+  .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 var(--font-sans);letter-spacing:.1em}
   .attachment-preview-close{border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.8);color:var(--gold-400);border-radius:50%;width:36px;height:36px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;transition:border-color var(--transition),transform var(--transition)}
   .attachment-preview-close:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
   .attachment-preview-body{position:relative;flex:1 1 auto;min-height:220px;padding:16px;border-radius:18px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.82);box-shadow:inset 0 0 22px rgba(0,0,0,.45);overflow:auto}
   .attachment-preview-body img,.attachment-preview-body video,.attachment-preview-body iframe{display:block;width:100%;height:100%;max-height:70vh;border-radius:14px;background:#050607}
   .attachment-preview-body video{background:#000}
   .attachment-preview-body iframe{border:0;min-height:60vh}
-  .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 'Inter','Noto Sans SC',sans-serif;text-align:center}
+  .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 var(--font-sans);text-align:center}
   .attachment-preview-spinner{width:40px;height:40px;border-radius:50%;border:3px solid rgba(201,168,106,.24);border-top-color:var(--gold-400);animation:attachment-preview-spin .9s linear infinite}
   .attachment-preview-loading-text{letter-spacing:.08em}
   @keyframes attachment-preview-spin{to{transform:rotate(360deg)}}
-  .attachment-preview-error{color:#fca5a5;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;padding:18px;text-align:center}
+  .attachment-preview-error{color:#fca5a5;font:14px/1.6 var(--font-sans);padding:18px;text-align:center}
   .attachment-preview-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-  .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
+  .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 var(--font-sans);letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
   .attachment-preview-list li .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
   .attachment-preview-tree{list-style:none;margin:0;padding:0;display:grid;gap:6px}
   .attachment-preview-tree ul{list-style:none;margin:6px 0 0;padding-left:18px;display:grid;gap:6px}
-  .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;color:var(--text-strong)}
+  .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 var(--font-sans);letter-spacing:.08em;color:var(--text-strong)}
   .attachment-preview-tree summary::-webkit-details-marker{display:none}
-  .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong)}
+  .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 var(--font-sans);letter-spacing:.04em;color:var(--text-strong)}
   .attachment-preview-tree .entry-label{display:flex;align-items:center;gap:8px;min-width:0}
   .attachment-preview-tree .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
   .attachment-preview-tree summary .entry-size{font-weight:500}
-  .attachment-docx{color:var(--text-strong);font:400 14px/1.75 'Noto Sans SC','Inter',sans-serif;display:grid;gap:14px}
+  .attachment-docx{color:var(--text-strong);font:400 14px/1.75 var(--font-sans);display:grid;gap:14px}
   .attachment-docx h1,.attachment-docx h2,.attachment-docx h3,.attachment-docx h4{color:var(--gold-400);margin:12px 0 6px;font-weight:600}
   .attachment-docx table{width:100%;border-collapse:collapse;margin:12px 0;border:1px solid rgba(201,168,106,.24)}
   .attachment-docx th,.attachment-docx td{border:1px solid rgba(201,168,106,.24);padding:6px 8px}
   .attachment-docx a{color:var(--gold-400)}
   .attachment-excel{display:grid;gap:16px}
   .attachment-excel .excel-sheet{border:1px solid rgba(201,168,106,.28);border-radius:14px;background:rgba(12,16,18,.78);padding:14px;box-shadow:inset 0 0 18px rgba(0,0,0,.36)}
-  .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
+  .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 var(--font-sans);color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
   .attachment-excel .excel-table{overflow:auto;border-radius:10px;border:1px solid rgba(201,168,106,.24)}
-  .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);background:rgba(12,16,18,.88)}
+  .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 var(--font-sans);color:var(--text-strong);background:rgba(12,16,18,.88)}
   .attachment-excel th,.attachment-excel td{border:1px solid rgba(201,168,106,.2);padding:6px 8px;text-align:left}
   .attachment-excel tbody tr:nth-child(even){background:rgba(201,168,106,.08)}
   .attachment-preview-footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
-  .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
+  .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
   .attachment-preview-download:hover{transform:translateY(-1px);box-shadow:0 16px 32px rgba(227,198,139,.25)}
   body[data-density='compact'] .item-title{font-size:15px}
   body[data-density='compact'] .item-desc{font-size:12px;opacity:.78}
@@ -478,6 +483,46 @@
         </div>
       </div>
       <input id="memo-import-input" type="file" accept="application/json" hidden>
+      <?php
+        $pageTotal=(int)($pagination['total'] ?? 0);
+        $renderPagination=function() use ($pagination,$cat,$q,$pageTotal){
+          if($pageTotal<=0){ return ''; }
+          $buildPageUrl=function(int $targetPage) use ($cat,$q){
+            $params=['cat'=>(string)$cat];
+            if($q!==''){ $params['q']=$q; }
+            if($targetPage>1){ $params['page']=$targetPage; }
+            return '?' . http_build_query($params);
+          };
+          $page=max(1,(int)($pagination['page'] ?? 1));
+          $pages=max(1,(int)($pagination['pages'] ?? 1));
+          $from=max(0,(int)($pagination['from'] ?? 0));
+          $to=max(0,(int)($pagination['to'] ?? 0));
+          $hasPrev=!empty($pagination['has_prev']) && !empty($pagination['prev_page']);
+          $hasNext=!empty($pagination['has_next']) && !empty($pagination['next_page']);
+          ob_start();
+          ?>
+          <nav class="pagination" aria-label="分页导航">
+            <div class="page-info">第 <?php echo $page; ?> / <?php echo $pages; ?> 页 · 显示 <?php echo $from; ?>-<?php echo $to; ?> / <?php echo $pageTotal; ?> 条</div>
+            <div class="page-links" role="group" aria-label="分页按钮">
+              <?php if ($hasPrev): ?>
+                <a class="page-btn" href="<?php echo h($buildPageUrl((int)$pagination['prev_page'])); ?>" rel="prev">上一页</a>
+              <?php else: ?>
+                <span class="page-btn disabled" aria-disabled="true">上一页</span>
+              <?php endif; ?>
+              <?php if ($hasNext): ?>
+                <a class="page-btn" href="<?php echo h($buildPageUrl((int)$pagination['next_page'])); ?>" rel="next">下一页</a>
+              <?php else: ?>
+                <span class="page-btn disabled" aria-disabled="true">下一页</span>
+              <?php endif; ?>
+            </div>
+          </nav>
+          <?php
+          return ob_get_clean();
+        };
+      ?>
+      <?php if ($pageTotal > 0): ?>
+        <?php echo $renderPagination(); ?>
+      <?php endif; ?>
       <div class="items" id="items">
         <?php if (!$items): ?>
           <div class="item item-empty">没有条目 · No items</div>
@@ -564,6 +609,9 @@
           </article>
         <?php endforeach; ?>
       </div>
+      <?php if ($pageTotal > 0): ?>
+        <?php echo $renderPagination(); ?>
+      <?php endif; ?>
       <div class="shortcuts">
         快捷键：<span class="kbd">/</span> 聚焦搜索。
       </div>

--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -6,9 +6,6 @@
     <title>详情 · <?php echo h($it['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
     <style>
       :root{
         --bg-void:#0A0C0E;
@@ -48,9 +45,11 @@
         --danger-soft:rgba(209,75,75,.32);
         --grid-size:64px;
         --transition:var(--t) var(--ease);
+        --font-sans:'Inter','Source Han Sans','Noto Sans SC','PingFang SC','Microsoft YaHei','Helvetica Neue',Arial,sans-serif;
+        --font-serif:'Noto Serif SC','Source Han Serif SC','Songti SC','STSong','serif';
       }
       *,*::before,*::after{box-sizing:border-box}
-      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.65 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow-x:hidden}
+      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.65 var(--font-sans);letter-spacing:.01em;position:relative;overflow-x:hidden}
       body{background:
         radial-gradient(1200px 700px at 70% -10%,rgba(227,198,139,.06),transparent 60%),
         linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
@@ -69,10 +68,10 @@
       }
       .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.18}
       a{color:inherit;text-decoration:none}
-      h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
+      h1,h2,h3,h4{font-family:var(--font-serif);color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
       .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px;position:relative;z-index:0}
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.2);opacity:.6;pointer-events:none}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(227,198,139,.65);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.62));color:#1b1306;cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 14px 32px rgba(227,198,139,.25),0 0 24px rgba(227,198,139,.18);overflow:hidden}
+      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(227,198,139,.65);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.62));color:#1b1306;cursor:pointer;text-transform:uppercase;font:600 13px/1.2 var(--font-sans);letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 14px 32px rgba(227,198,139,.25),0 0 24px rgba(227,198,139,.18);overflow:hidden}
       .btn::after{content:none}
       .btn:hover{transform:translateY(-2px);box-shadow:0 18px 36px rgba(227,198,139,.3),0 0 28px rgba(227,198,139,.24)}
       .btn:active{transform:translateY(0);box-shadow:0 8px 20px rgba(227,198,139,.22)}
@@ -81,8 +80,8 @@
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 2px rgba(227,198,139,.25)}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.94));border:1px solid rgba(201,168,106,.32);border-radius:24px;padding:28px;box-shadow:var(--shadow-1);backdrop-filter:blur(16px)}
       .card::before{content:"";position:absolute;inset:12px;border-radius:calc(24px - 6px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 40px rgba(227,198,139,.1);pointer-events:none}
-      .title{font:600 26px/1.35 'Cinzel','Noto Serif SC',serif;margin:0 0 10px;color:var(--gold-400);letter-spacing:.02em;text-transform:uppercase}
-      .meta{color:var(--text-muted);font:500 13px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase}
+      .title{font:600 26px/1.35 var(--font-serif);margin:0 0 10px;color:var(--gold-400);letter-spacing:.02em;text-transform:uppercase}
+      .meta{color:var(--text-muted);font:500 13px/1.6 var(--font-sans);letter-spacing:.14em;text-transform:uppercase}
       .split{display:grid;grid-template-columns:minmax(320px,1fr) minmax(320px,1fr);gap:24px;align-items:start}
       @media (max-width:920px){
         .split{grid-template-columns:1fr}
@@ -92,7 +91,7 @@
       .editbox::before,.preview::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-md) - 4px);border:1px solid rgba(201,168,106,.2);opacity:.6;pointer-events:none}
       .editbox input,
       .editbox select,
-      .editbox textarea{width:100%;padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.72);color:var(--text-strong);font:500 15px/1.5 'Noto Sans SC','Inter',sans-serif;letter-spacing:.03em;transition:border-color var(--transition),box-shadow var(--transition)}
+      .editbox textarea{width:100%;padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.32);background:rgba(12,16,18,.72);color:var(--text-strong);font:500 15px/1.5 var(--font-sans);letter-spacing:.03em;transition:border-color var(--transition),box-shadow var(--transition)}
       .editbox input::placeholder,
       .editbox textarea::placeholder{color:var(--text-muted)}
       .editbox input:focus,
@@ -105,23 +104,23 @@
       .md-body{color:var(--text-dim)}
       .md-body img{max-width:100%;height:auto;border:1px solid rgba(201,168,106,.32);border-radius:var(--r-sm);box-shadow:0 18px 36px rgba(0,0,0,.55),0 0 28px rgba(227,198,139,.12)}
       .section{margin-top:28px;padding-top:20px;border-top:1px solid var(--divider)}
-      .section h2{margin:0 0 12px;font:600 18px/1.4 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.08em}
-      .section h3{margin:12px 0 10px;font:600 15px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);text-transform:uppercase;letter-spacing:.14em}
-      .section label{display:block;font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;margin-bottom:8px;color:var(--text-muted);text-transform:uppercase}
-      .status-pill{display:inline-flex;align-items:center;gap:6px;border-radius:999px;border:1px solid rgba(201,168,106,.36);background:rgba(12,16,18,.82);padding:4px 14px;color:var(--text-dim);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.2em}
+      .section h2{margin:0 0 12px;font:600 18px/1.4 var(--font-serif);color:var(--gold-400);letter-spacing:.08em}
+      .section h3{margin:12px 0 10px;font:600 15px/1.4 var(--font-sans);color:var(--text-strong);text-transform:uppercase;letter-spacing:.14em}
+      .section label{display:block;font:600 12px/1.4 var(--font-sans);letter-spacing:.16em;margin-bottom:8px;color:var(--text-muted);text-transform:uppercase}
+      .status-pill{display:inline-flex;align-items:center;gap:6px;border-radius:999px;border:1px solid rgba(201,168,106,.36);background:rgba(12,16,18,.82);padding:4px 14px;color:var(--text-dim);font:600 12px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.2em}
       .status-pill::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--gold-500);box-shadow:0 0 8px rgba(227,198,139,.4)}
       .attachment-panel{display:flex;flex-direction:column;gap:16px}
       .attachment-panel-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
-      .attachment-panel-title{font:600 14px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400)}
-      .attachment-panel-meta{color:var(--text-muted);font:12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
-      .attachment-empty{padding:18px;border:1px dashed rgba(201,168,106,.28);border-radius:16px;background:rgba(12,16,18,.66);color:var(--text-muted);text-align:center;font:500 13px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.06em}
+      .attachment-panel-title{font:600 14px/1.2 var(--font-sans);letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400)}
+      .attachment-panel-meta{color:var(--text-muted);font:12px/1.4 var(--font-sans);letter-spacing:.1em}
+      .attachment-empty{padding:18px;border:1px dashed rgba(201,168,106,.28);border-radius:16px;background:rgba(12,16,18,.66);color:var(--text-muted);text-align:center;font:500 13px/1.6 var(--font-sans);letter-spacing:.06em}
       .attachment-list{display:grid;gap:12px}
       .attachment-row{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;padding:14px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);box-shadow:var(--shadow-1)}
       .attachment-main{display:flex;align-items:center;gap:12px;min-width:0;flex:1}
       .attachment-icon{font-size:26px;line-height:1}
       .attachment-info{display:grid;gap:4px;min-width:0}
-      .attachment-name{font:600 14px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);letter-spacing:.04em;word-break:break-all}
-      .attachment-detail{color:var(--text-muted);font:12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .attachment-name{font:600 14px/1.4 var(--font-sans);color:var(--text-strong);letter-spacing:.04em;word-break:break-all}
+      .attachment-detail{color:var(--text-muted);font:12px/1.4 var(--font-sans);letter-spacing:.08em}
       .attachment-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
       .attachment-actions form{margin:0}
       .timeline{position:relative;margin-top:22px;margin-left:18px;padding-left:34px;color:var(--text-muted)}
@@ -130,13 +129,13 @@
       .tl-item::before{content:"";position:absolute;inset:8px;border-radius:calc(var(--r-md) - 4px);border:1px dashed rgba(201,168,106,.2);pointer-events:none;opacity:.7}
       .tl-item .tl-dot{position:absolute;left:-28px;top:22px;width:16px;height:16px;border-radius:50%;background:linear-gradient(135deg,rgba(201,168,106,.92),rgba(170,140,84,.9));box-shadow:0 0 24px rgba(227,198,139,.32)}
       .tl-item .tl-dot::after{content:"";position:absolute;inset:-6px;border-radius:inherit;border:1px dashed rgba(201,168,106,.45);opacity:.85;box-shadow:0 0 18px rgba(227,198,139,.24)}
-      .tl-head{display:flex;gap:12px;align-items:center;color:var(--text-strong);font-family:'Inter','Noto Sans SC',sans-serif}
+      .tl-head{display:flex;gap:12px;align-items:center;color:var(--text-strong);font-family:var(--font-sans)}
       .tl-item.done .tl-head div,.tl-item.done .md-body{opacity:.72;text-decoration:line-through}
       .tl-item.done{background:linear-gradient(160deg,rgba(36,194,160,.18),rgba(15,22,20,.92));border-color:rgba(36,194,160,.42);box-shadow:0 0 28px rgba(36,194,160,.28)}
       .drag{cursor:grab;color:var(--text-muted);user-select:none;font-size:18px}
-      .ts{color:var(--text-dim);font:12px/1 'Inter','Noto Sans SC',sans-serif;margin-left:6px;letter-spacing:.12em}
-      details summary{cursor:pointer;color:var(--text-muted);text-transform:uppercase;letter-spacing:.16em;font:500 12px/1.4 'Inter','Noto Sans SC',sans-serif}
-      .save-tip{color:var(--gold-400);font:12px/1 'Inter','Noto Sans SC',sans-serif;display:none;margin-left:10px;text-transform:uppercase;letter-spacing:.18em}
+      .ts{color:var(--text-dim);font:12px/1 var(--font-sans);margin-left:6px;letter-spacing:.12em}
+      details summary{cursor:pointer;color:var(--text-muted);text-transform:uppercase;letter-spacing:.16em;font:500 12px/1.4 var(--font-sans)}
+      .save-tip{color:var(--gold-400);font:12px/1 var(--font-sans);display:none;margin-left:10px;text-transform:uppercase;letter-spacing:.18em}
       .save-tip.dirty{color:var(--accent-crimson)}
       .save-tip.show{display:inline-block}
       .placeholder-muted{color:var(--text-muted)}
@@ -144,70 +143,70 @@
       .toast.error{border-color:rgba(209,75,75,.52);color:#F6D6D6;box-shadow:0 22px 46px rgba(209,75,75,.28)}
       .toast .icon{font-size:18px;color:var(--gold-400)}
       .toast.error .icon{color:var(--accent-crimson)}
-      .toast .body{flex:1;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .toast .body{flex:1;font:14px/1.6 var(--font-sans);letter-spacing:.08em}
       .toast button{background:none;border:0;color:inherit;cursor:pointer}
       .attachment-preview-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(5,7,10,.78);backdrop-filter:blur(18px);z-index:180}
       .attachment-preview-backdrop[data-open="true"]{display:flex}
       .attachment-preview-panel{width:min(920px,calc(100vw - 32px));max-height:min(90vh,96svh);background:linear-gradient(165deg,rgba(21,26,30,.95),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.34);border-radius:24px;box-shadow:0 32px 64px rgba(0,0,0,.68),0 0 34px rgba(227,198,139,.2);padding:20px;display:flex;flex-direction:column;gap:16px;position:relative}
       .attachment-preview-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-      .attachment-preview-title{margin:0;font:600 18px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
-      .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
+      .attachment-preview-title{margin:0;font:600 18px/1.2 var(--font-serif);color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
+      .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 var(--font-sans);letter-spacing:.1em}
       .attachment-preview-close{border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.8);color:var(--gold-400);border-radius:50%;width:36px;height:36px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;transition:border-color var(--transition),transform var(--transition)}
       .attachment-preview-close:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
       .attachment-preview-body{position:relative;flex:1 1 auto;min-height:220px;padding:16px;border-radius:18px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.82);box-shadow:inset 0 0 22px rgba(0,0,0,.45);overflow:auto}
       .attachment-preview-body img,.attachment-preview-body video,.attachment-preview-body iframe{display:block;width:100%;height:100%;max-height:70vh;border-radius:14px;background:#050607}
       .attachment-preview-body video{background:#000}
       .attachment-preview-body iframe{border:0;min-height:60vh}
-      .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 'Inter','Noto Sans SC',sans-serif;text-align:center}
+      .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 var(--font-sans);text-align:center}
       .attachment-preview-spinner{width:40px;height:40px;border-radius:50%;border:3px solid rgba(201,168,106,.24);border-top-color:var(--gold-400);animation:attachment-preview-spin .9s linear infinite}
       .attachment-preview-loading-text{letter-spacing:.08em}
       @keyframes attachment-preview-spin{to{transform:rotate(360deg)}}
-      .attachment-preview-error{color:#fca5a5;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;padding:18px;text-align:center}
+      .attachment-preview-error{color:#fca5a5;font:14px/1.6 var(--font-sans);padding:18px;text-align:center}
       .attachment-preview-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-      .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
+      .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 var(--font-sans);letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
       .attachment-preview-list li .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
       .attachment-preview-tree{list-style:none;margin:0;padding:0;display:grid;gap:6px}
       .attachment-preview-tree ul{list-style:none;margin:6px 0 0;padding-left:18px;display:grid;gap:6px}
-      .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;color:var(--text-strong)}
+      .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 var(--font-sans);letter-spacing:.08em;color:var(--text-strong)}
       .attachment-preview-tree summary::-webkit-details-marker{display:none}
-      .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong)}
+      .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 var(--font-sans);letter-spacing:.04em;color:var(--text-strong)}
       .attachment-preview-tree .entry-label{display:flex;align-items:center;gap:8px;min-width:0}
       .attachment-preview-tree .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
       .attachment-preview-tree summary .entry-size{font-weight:500}
-      .attachment-docx{color:var(--text-strong);font:400 14px/1.75 'Noto Sans SC','Inter',sans-serif;display:grid;gap:14px}
+      .attachment-docx{color:var(--text-strong);font:400 14px/1.75 var(--font-sans);display:grid;gap:14px}
       .attachment-docx h1,.attachment-docx h2,.attachment-docx h3,.attachment-docx h4{color:var(--gold-400);margin:12px 0 6px;font-weight:600}
       .attachment-docx table{width:100%;border-collapse:collapse;margin:12px 0;border:1px solid rgba(201,168,106,.24)}
       .attachment-docx th,.attachment-docx td{border:1px solid rgba(201,168,106,.24);padding:6px 8px}
       .attachment-docx a{color:var(--gold-400)}
       .attachment-excel{display:grid;gap:16px}
       .attachment-excel .excel-sheet{border:1px solid rgba(201,168,106,.28);border-radius:14px;background:rgba(12,16,18,.78);padding:14px;box-shadow:inset 0 0 18px rgba(0,0,0,.36)}
-      .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
+      .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 var(--font-sans);color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
       .attachment-excel .excel-table{overflow:auto;border-radius:10px;border:1px solid rgba(201,168,106,.24)}
-      .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);background:rgba(12,16,18,.88)}
+      .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 var(--font-sans);color:var(--text-strong);background:rgba(12,16,18,.88)}
       .attachment-excel th,.attachment-excel td{border:1px solid rgba(201,168,106,.2);padding:6px 8px;text-align:left}
       .attachment-excel tbody tr:nth-child(even){background:rgba(201,168,106,.08)}
       .attachment-preview-tree{list-style:none;margin:0;padding:0;display:grid;gap:6px}
       .attachment-preview-tree ul{list-style:none;margin:6px 0 0;padding-left:18px;display:grid;gap:6px}
-      .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;color:var(--text-strong)}
+      .attachment-preview-tree summary{cursor:pointer;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:600 13px/1.4 var(--font-sans);letter-spacing:.08em;color:var(--text-strong)}
       .attachment-preview-tree summary::-webkit-details-marker{display:none}
-      .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong)}
+      .attachment-preview-tree .tree-entry{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);font:13px/1.5 var(--font-sans);letter-spacing:.04em;color:var(--text-strong)}
       .attachment-preview-tree .entry-label{display:flex;align-items:center;gap:8px;min-width:0}
       .attachment-preview-tree .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
       .attachment-preview-tree summary .entry-size{font-weight:500}
-      .attachment-docx{color:var(--text-strong);font:400 14px/1.75 'Noto Sans SC','Inter',sans-serif;display:grid;gap:14px}
+      .attachment-docx{color:var(--text-strong);font:400 14px/1.75 var(--font-sans);display:grid;gap:14px}
       .attachment-docx h1,.attachment-docx h2,.attachment-docx h3,.attachment-docx h4{color:var(--gold-400);margin:12px 0 6px;font-weight:600}
       .attachment-docx table{width:100%;border-collapse:collapse;margin:12px 0;border:1px solid rgba(201,168,106,.24)}
       .attachment-docx th,.attachment-docx td{border:1px solid rgba(201,168,106,.24);padding:6px 8px}
       .attachment-docx a{color:var(--gold-400)}
       .attachment-excel{display:grid;gap:16px}
       .attachment-excel .excel-sheet{border:1px solid rgba(201,168,106,.28);border-radius:14px;background:rgba(12,16,18,.78);padding:14px;box-shadow:inset 0 0 18px rgba(0,0,0,.36)}
-      .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
+      .attachment-excel .excel-sheet h3{margin:0 0 10px;font:600 14px/1.4 var(--font-sans);color:var(--gold-400);letter-spacing:.1em;text-transform:uppercase}
       .attachment-excel .excel-table{overflow:auto;border-radius:10px;border:1px solid rgba(201,168,106,.24)}
-      .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);background:rgba(12,16,18,.88)}
+      .attachment-excel table{width:100%;border-collapse:collapse;min-width:320px;font:13px/1.45 var(--font-sans);color:var(--text-strong);background:rgba(12,16,18,.88)}
       .attachment-excel th,.attachment-excel td{border:1px solid rgba(201,168,106,.2);padding:6px 8px;text-align:left}
       .attachment-excel tbody tr:nth-child(even){background:rgba(201,168,106,.08)}
       .attachment-preview-footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
-      .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
+      .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
       .attachment-preview-download:hover{transform:translateY(-1px);box-shadow:0 16px 32px rgba(227,198,139,.25)}
     </style>
     <script>

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -6,9 +6,6 @@
     <title>思维导图编辑器 · <?php echo h($mind['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
     <style>
       :root{
         --bg-void:#0A0C0E;
@@ -55,9 +52,11 @@
         --safe-right:env(safe-area-inset-right, 0px);
         --safe-bottom:env(safe-area-inset-bottom, 0px);
         --safe-left:env(safe-area-inset-left, 0px);
+        --font-sans:'Inter','Source Han Sans','Noto Sans SC','PingFang SC','Microsoft YaHei','Helvetica Neue',Arial,sans-serif;
+        --font-serif:'Noto Serif SC','Source Han Serif SC','Songti SC','STSong','serif';
       }
       *,*::before,*::after{box-sizing:border-box}
-      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.6 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow:hidden}
+      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.6 var(--font-sans);letter-spacing:.01em;position:relative;overflow:hidden}
       body{background:
         radial-gradient(1200px 700px at 72% -10%,rgba(227,198,139,.06),transparent 60%),
         linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
@@ -82,75 +81,75 @@
       .mind-info-bar[data-collapsed="true"]{max-height:20px;padding:0 12px;gap:0;min-width:auto;width:auto;border-radius:14px;border-color:rgba(201,168,106,.2);background:rgba(15,19,22,.82);box-shadow:0 12px 28px rgba(0,0,0,.45);overflow:hidden}
       .mind-info-content{display:flex;flex-direction:column;gap:12px;transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease);transform-origin:top}
       .mind-info-bar[data-collapsed="true"] .mind-info-content{opacity:0;transform:translateY(-6px);pointer-events:none}
-      .mind-info-handle{align-self:center;display:flex;align-items:center;justify-content:center;width:36px;height:20px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;cursor:pointer;transition:background var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),transform var(--t-fast) var(--ease);margin-bottom:4px}
+      .mind-info-handle{align-self:center;display:flex;align-items:center;justify-content:center;width:36px;height:20px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.16em;text-transform:uppercase;cursor:pointer;transition:background var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),transform var(--t-fast) var(--ease);margin-bottom:4px}
       .mind-info-handle .icon{font-size:14px;line-height:1}
       .mind-info-handle:hover{background:rgba(201,168,106,.2);border-color:rgba(227,198,139,.5)}
       .mind-info-handle:focus-visible{outline:3px solid rgba(75,195,209,.35);outline-offset:2px}
       .mind-info-bar[data-collapsed="true"] .mind-info-handle{margin-bottom:0}
       .mind-info-row{display:flex;align-items:center;gap:12px}
       .map-io{position:relative;flex:0 0 auto}
-      .map-io-button{padding:10px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.36);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:background var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
+      .map-io-button{padding:10px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.36);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:background var(--t-fast) var(--ease),border-color var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
       .map-io-button:hover{background:rgba(201,168,106,.2);border-color:rgba(227,198,139,.5)}
       .map-io-button:focus-visible{outline:3px solid rgba(75,195,209,.35);outline-offset:2px}
       .map-io[aria-expanded="true"] .map-io-button{background:rgba(201,168,106,.24)}
       .map-io-menu{position:absolute;top:calc(100% + 10px);right:0;display:none;flex-direction:column;gap:8px;padding:12px;border-radius:16px;border:1px solid rgba(201,168,106,.32);background:linear-gradient(180deg,rgba(21,26,30,.96),rgba(12,16,18,.92));box-shadow:0 16px 42px rgba(0,0,0,.55);min-width:180px;z-index:30}
       .map-io[aria-expanded="true"] .map-io-menu{display:flex}
-      .map-io-menu button{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78);color:var(--text-strong);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition),color var(--transition);text-align:left}
+      .map-io-menu button{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78);color:var(--text-strong);font:600 13px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition),color var(--transition);text-align:left}
       .map-io-menu button:hover{border-color:rgba(227,198,139,.6);background:rgba(201,168,106,.12);color:var(--gold-400)}
       .mind-export-overlay{position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px;padding:32px;background:rgba(6,8,10,.82);backdrop-filter:blur(20px);z-index:400;opacity:0;visibility:hidden;pointer-events:none;transition:opacity var(--transition),visibility var(--transition)}
       .mind-export-overlay[data-active="true"]{opacity:1;visibility:visible;pointer-events:auto}
       .mind-export-overlay .export-spinner{width:74px;height:74px;border-radius:50%;border:3px solid rgba(201,168,106,.18);border-top-color:rgba(227,198,139,.78);animation:exportSpin 1s linear infinite}
-      .mind-export-overlay .export-label{font:600 14px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.18em;text-transform:uppercase;color:var(--gold-400);text-align:center}
-      .mind-export-overlay .export-subtext{font:12px/1.6 'Inter','Noto Sans SC',sans-serif;color:var(--text-muted);letter-spacing:.12em;text-align:center;max-width:320px}
+      .mind-export-overlay .export-label{font:600 14px/1.6 var(--font-sans);letter-spacing:.18em;text-transform:uppercase;color:var(--gold-400);text-align:center}
+      .mind-export-overlay .export-subtext{font:12px/1.6 var(--font-sans);color:var(--text-muted);letter-spacing:.12em;text-align:center;max-width:320px}
       @media (prefers-reduced-motion: reduce){.mind-export-overlay{transition:none}.mind-export-overlay .export-spinner{animation-duration:1.6s}}
       @keyframes exportSpin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
       .mind-import-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:24px;background:rgba(6,8,10,.78);backdrop-filter:blur(18px);z-index:180}
       .mind-import-backdrop[data-open="true"]{display:flex}
       .mind-import-panel{background:linear-gradient(165deg,rgba(21,26,30,.95),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.36);border-radius:24px;box-shadow:0 32px 68px rgba(0,0,0,.68),0 0 32px rgba(227,198,139,.18);padding:24px;max-width:420px;width:100%;display:grid;gap:16px;position:relative}
       .mind-import-panel::before{content:"";position:absolute;inset:10px;border-radius:18px;border:1px dashed rgba(201,168,106,.26);opacity:.75;pointer-events:none}
-      .mind-import-panel h3{margin:0;font:600 18px/1.3 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase;text-align:center}
-      .mind-import-panel p{margin:0;color:var(--text-muted);font:13px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;text-align:center}
+      .mind-import-panel h3{margin:0;font:600 18px/1.3 var(--font-serif);color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase;text-align:center}
+      .mind-import-panel p{margin:0;color:var(--text-muted);font:13px/1.6 var(--font-sans);letter-spacing:.08em;text-align:center}
       .mind-import-options{display:grid;gap:10px}
-      .mind-import-options button{padding:12px 16px;border-radius:16px;border:1px solid rgba(227,198,139,.62);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.58));color:#1b1306;font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
+      .mind-import-options button{padding:12px 16px;border-radius:16px;border:1px solid rgba(227,198,139,.62);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.58));color:#1b1306;font:600 13px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
       .mind-import-options button:hover{transform:translateY(-2px);box-shadow:0 18px 36px rgba(227,198,139,.32),0 0 28px rgba(227,198,139,.24)}
       .mind-import-footer{display:flex;justify-content:flex-end}
-      .mind-import-footer button{padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
+      .mind-import-footer button{padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(21,26,30,.82);color:var(--gold-400);font:600 12px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.14em;cursor:pointer;transition:transform var(--transition),box-shadow var(--transition)}
       .mind-import-footer button:hover{transform:translateY(-2px);box-shadow:0 12px 26px rgba(227,198,139,.22)}
       .attachment-preview-backdrop{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;background:rgba(5,7,10,.78);backdrop-filter:blur(18px);z-index:280}
       .attachment-preview-backdrop[data-open="true"]{display:flex}
       .attachment-preview-panel{width:min(960px,calc(100vw - 32px));max-height:min(90vh,96svh);background:linear-gradient(165deg,rgba(21,26,30,.95),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.34);border-radius:24px;box-shadow:0 32px 64px rgba(0,0,0,.72),0 0 34px rgba(227,198,139,.2);padding:20px;display:flex;flex-direction:column;gap:16px;position:relative}
       .attachment-preview-header{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
-      .attachment-preview-title{margin:0;font:600 18px/1.2 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
-      .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
+      .attachment-preview-title{margin:0;font:600 18px/1.2 var(--font-serif);color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
+      .attachment-preview-meta{color:var(--text-muted);font:12px/1.5 var(--font-sans);letter-spacing:.1em}
       .attachment-preview-close{border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.8);color:var(--gold-400);border-radius:50%;width:36px;height:36px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;transition:border-color var(--transition),transform var(--transition)}
       .attachment-preview-close:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
       .attachment-preview-body{position:relative;flex:1 1 auto;min-height:220px;padding:16px;border-radius:18px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.82);box-shadow:inset 0 0 22px rgba(0,0,0,.45);overflow:auto}
       .attachment-preview-body img,.attachment-preview-body video,.attachment-preview-body iframe{display:block;width:100%;height:100%;max-height:70vh;border-radius:14px;background:#050607}
       .attachment-preview-body video{background:#000}
       .attachment-preview-body iframe{border:0;min-height:60vh}
-      .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 'Inter','Noto Sans SC',sans-serif;text-align:center}
+      .attachment-preview-loading{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px;color:var(--text-muted);font:14px/1.6 var(--font-sans);text-align:center}
       .attachment-preview-spinner{width:40px;height:40px;border-radius:50%;border:3px solid rgba(201,168,106,.24);border-top-color:var(--gold-400);animation:attachment-preview-spin .9s linear infinite}
       .attachment-preview-loading-text{letter-spacing:.08em}
       @keyframes attachment-preview-spin{to{transform:rotate(360deg)}}
-      .attachment-preview-error{color:#fca5a5;font:14px/1.6 'Inter','Noto Sans SC',sans-serif;padding:18px;text-align:center}
+      .attachment-preview-error{color:#fca5a5;font:14px/1.6 var(--font-sans);padding:18px;text-align:center}
       .attachment-preview-list{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-      .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 'Inter','Noto Sans SC',sans-serif;letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
+      .attachment-preview-list li{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.78);font:13px/1.5 var(--font-sans);letter-spacing:.04em;color:var(--text-strong);display:flex;justify-content:space-between;gap:12px;align-items:center}
       .attachment-preview-list li .entry-size{color:var(--text-muted);font-size:12px;letter-spacing:.08em}
       .attachment-preview-footer{display:flex;justify-content:flex-end;gap:10px;flex-wrap:wrap}
-      .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
+      .attachment-preview-download{display:inline-flex;align-items:center;justify-content:center;padding:10px 16px;border-radius:12px;border:1px solid rgba(201,168,106,.36);background:rgba(15,19,22,.85);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;cursor:pointer;text-decoration:none;transition:transform var(--transition),box-shadow var(--transition)}
       .attachment-preview-download:hover{transform:translateY(-1px);box-shadow:0 16px 32px rgba(227,198,139,.25)}
-      .map-back{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.08);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400);transition:background var(--transition),border-color var(--transition),transform var(--transition)}
+      .map-back{display:inline-flex;align-items:center;gap:6px;padding:8px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.08);font:600 12px/1 var(--font-sans);letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400);transition:background var(--transition),border-color var(--transition),transform var(--transition)}
       .map-back:hover{border-color:rgba(227,198,139,.6);background:rgba(201,168,106,.16);transform:translateY(-1px)}
       .mind-info-row .map-title-input{flex:1;min-width:0}
-      .map-meta{display:flex;flex-wrap:wrap;gap:10px;align-items:center;font:600 11px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--text-muted)}
+      .map-meta{display:flex;flex-wrap:wrap;gap:10px;align-items:center;font:600 11px/1.4 var(--font-sans);letter-spacing:.16em;text-transform:uppercase;color:var(--text-muted)}
       .map-meta span{white-space:nowrap}
-      .map-delete-btn{margin-left:auto;padding:6px 12px;border-radius:12px;border:1px solid rgba(209,75,75,.52);background:rgba(209,75,75,.12);color:#F6D6D6;font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background var(--transition)}
+      .map-delete-btn{margin-left:auto;padding:6px 12px;border-radius:12px;border:1px solid rgba(209,75,75,.52);background:rgba(209,75,75,.12);color:#F6D6D6;font:600 11px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background var(--transition)}
       .map-delete-btn:hover{border-color:rgba(209,75,75,.72);background:rgba(209,75,75,.18)}
       .map-delete-btn:focus-visible{outline:3px solid rgba(209,75,75,.35);outline-offset:2px}
       .map-delete-btn[disabled]{opacity:.5;cursor:not-allowed}
-      .map-title-input{width:100%;padding:12px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.34);background:rgba(12,16,18,.78);color:var(--text-strong);font:600 17px/1.35 'Cinzel','Noto Serif SC',serif;letter-spacing:.08em;transition:border-color var(--transition),box-shadow var(--transition)}
+      .map-title-input{width:100%;padding:12px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.34);background:rgba(12,16,18,.78);color:var(--text-strong);font:600 17px/1.35 var(--font-serif);letter-spacing:.08em;transition:border-color var(--transition),box-shadow var(--transition)}
       .map-title-input:focus{outline:none;border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.18)}
-      .save-state{margin-left:auto;padding:6px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.12);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400);opacity:0;transform:translateY(-6px);transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
+      .save-state{margin-left:auto;padding:6px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.12);font:600 11px/1 var(--font-sans);letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400);opacity:0;transform:translateY(-6px);transition:opacity var(--t-fast) var(--ease),transform var(--t-fast) var(--ease)}
       .save-state.show{opacity:1;transform:translateY(0)}
       .save-state.dirty{color:var(--accent-crimson);border-color:rgba(209,75,75,.45);background:rgba(209,75,75,.12)}
       @media (max-width:720px){
@@ -177,7 +176,7 @@
       .mind-viewport,.mind-links{position:absolute;top:0;left:0;transform-origin:0 0}
       .mind-links{pointer-events:auto;overflow:visible}
       .mind-link-controls{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:12}
-      .mind-link-controls .edge-insert-btn{position:absolute;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:14px;border:1px solid rgba(227,198,139,.65);background:linear-gradient(160deg,rgba(28,32,36,.96),rgba(12,16,18,.92));color:var(--gold-400);font:600 18px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em;pointer-events:auto;cursor:pointer;box-shadow:0 12px 28px rgba(0,0,0,.52),0 0 0 1px rgba(227,198,139,.32) inset,0 0 26px rgba(227,198,139,.22);transform:translate(-50%,-50%);transition:transform var(--transition),background-color var(--transition),border-color var(--transition),box-shadow var(--transition);text-shadow:0 0 10px rgba(227,198,139,.4);isolation:isolate}
+      .mind-link-controls .edge-insert-btn{position:absolute;display:flex;align-items:center;justify-content:center;width:36px;height:36px;border-radius:14px;border:1px solid rgba(227,198,139,.65);background:linear-gradient(160deg,rgba(28,32,36,.96),rgba(12,16,18,.92));color:var(--gold-400);font:600 18px/1 var(--font-sans);letter-spacing:.08em;pointer-events:auto;cursor:pointer;box-shadow:0 12px 28px rgba(0,0,0,.52),0 0 0 1px rgba(227,198,139,.32) inset,0 0 26px rgba(227,198,139,.22);transform:translate(-50%,-50%);transition:transform var(--transition),background-color var(--transition),border-color var(--transition),box-shadow var(--transition);text-shadow:0 0 10px rgba(227,198,139,.4);isolation:isolate}
       .mind-link-controls .edge-insert-btn::before{content:"";position:absolute;inset:5px;border-radius:12px;background:radial-gradient(circle at 50% 40%,rgba(227,198,139,.32),rgba(227,198,139,.08) 65%,rgba(227,198,139,0) 100%);box-shadow:inset 0 0 18px rgba(227,198,139,.24);z-index:-1;opacity:.9}
       .mind-link-controls .edge-insert-btn::after{content:"";position:absolute;inset:-10px;border-radius:18px;background:radial-gradient(circle,rgba(227,198,139,.18),rgba(227,198,139,0) 70%);filter:blur(4px);opacity:.75;z-index:-2}
       .mind-link-controls .edge-insert-btn:hover{background:linear-gradient(160deg,rgba(36,42,48,.98),rgba(18,22,26,.94));border-color:rgba(227,198,139,.85);box-shadow:0 16px 32px rgba(0,0,0,.55),0 0 0 1px rgba(227,198,139,.4) inset,0 0 34px rgba(227,198,139,.3)}
@@ -196,7 +195,7 @@
       .mind-relations .relation-highlight{stroke:rgba(255,242,218,.32);stroke-width:0.8;transition:stroke var(--transition),stroke-width var(--transition),opacity var(--transition)}
       .mind-relations .relation-core{pointer-events:stroke;cursor:pointer}
       .mind-relations .relation-highlight{pointer-events:none}
-      .mind-relations .relation-direction{font:600 10px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.32em;text-transform:uppercase;fill:rgba(227,198,139,.75);pointer-events:none;mix-blend-mode:screen}
+      .mind-relations .relation-direction{font:600 10px/1 var(--font-sans);letter-spacing:.32em;text-transform:uppercase;fill:rgba(227,198,139,.75);pointer-events:none;mix-blend-mode:screen}
       .mind-relations .relation-direction.reverse{fill:rgba(191,242,255,.65)}
       .mind-relations .relation-direction textPath{dominant-baseline:middle}
       .mind-relations .relation-direction.reverse textPath{dominant-baseline:hanging}
@@ -206,15 +205,15 @@
       .mind-relations .relation-group[data-selected="true"] .relation-highlight{stroke:rgba(255,255,255,.88);stroke-width:2;opacity:1;animation:relationGlowPulse 1.2s ease-in-out infinite}
       .mind-relations .relation-core[data-bidirectional="true"]{stroke-dasharray:0}
       .mind-nodes{position:absolute;top:0;left:0;pointer-events:none}
-      .jsmind-node{position:absolute;display:flex;flex-direction:column;align-items:flex-start;gap:10px;padding:18px 20px;border-radius:var(--r-md);color:var(--text-strong);font:600 14px/1.5 'Inter','Noto Sans SC',sans-serif;min-width:170px;max-width:320px;background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));border:1.6px solid rgba(201,168,106,.32);box-shadow:0 20px 48px rgba(0,0,0,.58),0 0 30px rgba(227,198,139,.12);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),filter var(--transition);backdrop-filter:blur(12px);letter-spacing:.04em;pointer-events:auto}
+      .jsmind-node{position:absolute;display:flex;flex-direction:column;align-items:flex-start;gap:10px;padding:18px 20px;border-radius:var(--r-md);color:var(--text-strong);font:600 14px/1.5 var(--font-sans);min-width:170px;max-width:320px;background:linear-gradient(180deg,rgba(21,26,30,.94),rgba(15,19,22,.96));border:1.6px solid rgba(201,168,106,.32);box-shadow:0 20px 48px rgba(0,0,0,.58),0 0 30px rgba(227,198,139,.12);transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition),filter var(--transition);backdrop-filter:blur(12px);letter-spacing:.04em;pointer-events:auto}
       .jsmind-node::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-md) - 4px);border:1px solid rgba(201,168,106,.28);opacity:.85;pointer-events:none;box-shadow:0 0 24px rgba(227,198,139,.18)}
       .jsmind-node::after{content:"";position:absolute;inset:-14px;border-radius:calc(var(--r-md) + 10px);border:1px dashed rgba(201,168,106,.26);opacity:0;pointer-events:none;box-shadow:0 0 24px rgba(227,198,139,.16)}
-      .jsmind-node .node-topic{font:600 16px/1.45 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.06em;text-transform:uppercase}
-      .jsmind-node .node-meta{display:flex;flex-wrap:wrap;gap:8px;color:var(--text-dim);font:500 12px/1.4 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.16em}
+      .jsmind-node .node-topic{font:600 16px/1.45 var(--font-serif);color:var(--gold-400);letter-spacing:.06em;text-transform:uppercase}
+      .jsmind-node .node-meta{display:flex;flex-wrap:wrap;gap:8px;color:var(--text-dim);font:500 12px/1.4 var(--font-sans);text-transform:uppercase;letter-spacing:.16em}
       .jsmind-node .node-meta span{padding:2px 8px;border-radius:999px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78)}
-      .jsmind-node .node-body{color:var(--text-muted);font:400 13px/1.7 'Noto Sans SC','Inter',sans-serif}
-      .jsmind-node .node-note{color:var(--text-muted);font:400 13px/1.7 'Noto Sans SC','Inter',sans-serif;white-space:pre-wrap;word-break:break-word}
-      .jsmind-node .node-footer{display:flex;gap:8px;flex-wrap:wrap;font:600 11px/1 'Inter','Noto Sans SC',sans-serif;color:var(--text-dim);letter-spacing:.14em;text-transform:uppercase}
+      .jsmind-node .node-body{color:var(--text-muted);font:400 13px/1.7 var(--font-sans)}
+      .jsmind-node .node-note{color:var(--text-muted);font:400 13px/1.7 var(--font-sans);white-space:pre-wrap;word-break:break-word}
+      .jsmind-node .node-footer{display:flex;gap:8px;flex-wrap:wrap;font:600 11px/1 var(--font-sans);color:var(--text-dim);letter-spacing:.14em;text-transform:uppercase}
       .jsmind-node.isroot{border-width:2px;border-color:rgba(227,198,139,.55);box-shadow:0 0 0 1px rgba(227,198,139,.25),0 30px 60px rgba(0,0,0,.6)}
       .jsmind-node.isroot::after{opacity:.42;transform:scale(.95);box-shadow:0 0 36px rgba(227,198,139,.28)}
       .jsmind-node.selected{border-color:var(--gold-400);box-shadow:0 0 0 1px rgba(227,198,139,.32),0 0 40px rgba(227,198,139,.26);transform:translateY(-2px)}
@@ -230,7 +229,7 @@
       .jsmind-node.relation-target{border-style:dashed;border-color:rgba(75,195,209,.6)}
       .jsmind-node.is-collapsed{border-style:dashed;border-color:rgba(201,168,106,.4);background:linear-gradient(180deg,rgba(21,26,30,.86),rgba(12,16,18,.9))}
       .jsmind-node:not(.isroot) .node-topic::before{content:"";display:inline-block;width:6px;height:6px;margin-right:8px;border-radius:50%;background:var(--gold-400);box-shadow:0 0 6px rgba(227,198,139,.4);vertical-align:middle}
-      .node-collapse-marker{position:absolute;right:18px;bottom:16px;display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;box-shadow:0 0 12px rgba(227,198,139,.18);cursor:pointer;pointer-events:auto;transition:background var(--transition),border-color var(--transition),transform var(--transition)}
+      .node-collapse-marker{position:absolute;right:18px;bottom:16px;display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:rgba(201,168,106,.12);color:var(--gold-400);font:600 11px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;box-shadow:0 0 12px rgba(227,198,139,.18);cursor:pointer;pointer-events:auto;transition:background var(--transition),border-color var(--transition),transform var(--transition)}
       .node-collapse-marker:hover{transform:translateY(-1px);border-color:rgba(201,168,106,.48)}
       .node-collapse-marker:focus-visible{outline:3px solid rgba(75,195,209,.35);outline-offset:2px}
       .node-collapse-marker .icon{font-size:14px;line-height:1}
@@ -238,7 +237,7 @@
       .mind-dock-wrap{position:fixed;left:50%;bottom:calc(var(--safe-bottom) + 18px);transform:translateX(-50%);pointer-events:none;z-index:120;max-width:min(calc(100vw - 32px - var(--safe-left) - var(--safe-right)),1120px);width:100%;display:flex;justify-content:center}
       .mind-dock{pointer-events:auto;display:flex;flex-wrap:nowrap;align-items:stretch;justify-content:center;gap:14px;padding:16px 24px;border-radius:32px;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(12,16,18,.85));border:1px solid rgba(201,168,106,.32);box-shadow:0 18px 40px rgba(0,0,0,.55),0 0 32px rgba(227,198,139,.12) inset;backdrop-filter:blur(12px);position:relative;width:100%;max-width:100%;box-sizing:border-box;touch-action:pan-x pan-y;flex:0 1 auto;margin:0 auto;overflow-x:auto;scrollbar-width:none;-webkit-overflow-scrolling:touch;overscroll-behavior-x:contain}
       .mind-dock::-webkit-scrollbar{display:none}
-      .dock-btn{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;height:66px;border-radius:18px;padding:8px 6px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 clamp(90px,9vw,132px);min-width:74px;max-width:148px}
+      .dock-btn{position:relative;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;height:66px;border-radius:18px;padding:8px 6px;background:rgba(201,168,106,.08);border:1px solid rgba(201,168,106,.36);color:var(--gold-400);font:600 13px/1 var(--font-sans);text-transform:uppercase;letter-spacing:.12em;cursor:pointer;transition:transform var(--transition),border-color var(--transition),box-shadow var(--transition),background-color var(--transition);touch-action:manipulation;flex:1 1 clamp(90px,9vw,132px);min-width:74px;max-width:148px}
       .dock-btn .icon{font-size:20px;line-height:1}
       .dock-btn .label{display:block;font-size:12px;line-height:1;text-align:center}
       .dock-btn:hover{transform:translateY(-3px);border-color:var(--gold-500);background:rgba(201,168,106,.16);box-shadow:0 0 26px rgba(227,198,139,.18)}
@@ -255,7 +254,7 @@
       @media (max-width:720px){.mind-dock-wrap{max-width:calc(100vw - 24px)}.mind-dock{padding:12px 18px;border-radius:26px;gap:10px;justify-content:flex-start}.dock-btn{height:58px;flex:0 1 clamp(72px,24vw,112px);min-width:64px}.dock-btn .label{font-size:11px}}
       @media (max-width:520px){.mind-dock-wrap{max-width:calc(100vw - 20px)}.mind-dock{padding:12px 16px;gap:8px;justify-content:flex-start}.dock-btn{height:56px;flex:0 1 clamp(66px,28vw,98px);min-width:58px}.dock-btn .icon{font-size:18px}.dock-sep{display:none}}
       @media (prefers-reduced-motion: reduce){.dock-btn,.dock-btn:hover{transition:none!important;transform:none!important}}
-      .mind-relation-toast{position:absolute;left:50%;top:24px;transform:translateX(-50%) translateY(-8px);padding:10px 16px;border-radius:18px;border:1px solid rgba(75,195,209,.4);background:rgba(10,16,20,.88);color:rgba(191,242,255,.92);font:600 12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;box-shadow:0 18px 40px rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity var(--transition),transform var(--transition);z-index:110}
+      .mind-relation-toast{position:absolute;left:50%;top:24px;transform:translateX(-50%) translateY(-8px);padding:10px 16px;border-radius:18px;border:1px solid rgba(75,195,209,.4);background:rgba(10,16,20,.88);color:rgba(191,242,255,.92);font:600 12px/1.4 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;box-shadow:0 18px 40px rgba(0,0,0,.55);opacity:0;pointer-events:none;transition:opacity var(--transition),transform var(--transition);z-index:110}
       .mind-relation-toast[data-visible="true"]{opacity:1;transform:translateX(-50%) translateY(0)}
       .mind-shell[data-relation-mode] .mind-stage::after{content:"";position:absolute;inset:0;border:1px dashed rgba(75,195,209,.35);border-radius:inherit;pointer-events:none;animation:relationPulse 1.2s infinite ease-in-out}
       @keyframes relationPulse{0%{opacity:.35}50%{opacity:.8}100%{opacity:.35}}
@@ -266,13 +265,13 @@
       .node-popover .sheet-handle{display:none;width:56px;height:5px;border-radius:999px;background:rgba(201,168,106,.32);margin:4px auto 8px}
       .node-popover[data-mode="sheet"] .sheet-handle{display:block}
       .node-popover header{display:flex;align-items:center;justify-content:space-between;gap:12px}
-      .node-popover h2{margin:0;font:600 16px/1 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.14em;text-transform:uppercase}
+      .node-popover h2{margin:0;font:600 16px/1 var(--font-serif);color:var(--gold-400);letter-spacing:.14em;text-transform:uppercase}
       .node-popover button.close{background:none;border:1px solid rgba(201,168,106,.3);border-radius:999px;color:var(--gold-400);width:32px;height:32px;cursor:pointer}
       .node-popover button.close:hover{border-color:var(--gold-500)}
       .node-popover form{display:grid;gap:14px}
       .node-popover .field{display:grid;gap:8px}
-      .node-popover label{font:600 12px/1.2 'Inter','Noto Sans SC',sans-serif;color:var(--text-muted);letter-spacing:.14em;text-transform:uppercase}
-      .node-popover input,.node-popover select,.node-popover textarea{width:100%;padding:10px 12px;border-radius:14px;border:1px solid rgba(201,168,106,.3);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 14px/1.5 'Noto Sans SC','Inter',sans-serif;letter-spacing:.04em;transition:border-color var(--transition),box-shadow var(--transition)}
+      .node-popover label{font:600 12px/1.2 var(--font-sans);color:var(--text-muted);letter-spacing:.14em;text-transform:uppercase}
+      .node-popover input,.node-popover select,.node-popover textarea{width:100%;padding:10px 12px;border-radius:14px;border:1px solid rgba(201,168,106,.3);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 14px/1.5 var(--font-sans);letter-spacing:.04em;transition:border-color var(--transition),box-shadow var(--transition)}
       .node-popover input:focus,.node-popover select:focus,.node-popover textarea:focus{outline:none;border-color:var(--gold-500);box-shadow:0 0 0 2px rgba(227,198,139,.18)}
       .node-popover textarea{min-height:120px;resize:vertical}
       .node-popover .fold-field{padding-top:6px}
@@ -283,48 +282,48 @@
       .toggle-switch .thumb{position:absolute;top:2px;left:2px;width:20px;height:20px;border-radius:50%;background:var(--gold-500);box-shadow:0 0 12px rgba(227,198,139,.45);transition:transform var(--transition)}
       .toggle-switch input:checked + .track{background:rgba(36,194,160,.2);border-color:rgba(36,194,160,.4)}
       .toggle-switch input:checked + .track .thumb{transform:translateX(24px)}
-      .toggle-switch .toggle-text{font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;color:var(--text-dim)}
-      .fold-hint{margin:8px 0 0;font:500 12px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--text-muted)}
+      .toggle-switch .toggle-text{font:600 11px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;color:var(--text-dim)}
+      .fold-hint{margin:8px 0 0;font:500 12px/1.4 var(--font-sans);color:var(--text-muted)}
       .node-popover .popover-actions{display:flex;justify-content:flex-end;gap:10px}
-      .node-popover .popover-actions button{padding:10px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.32);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition)}
+      .node-popover .popover-actions button{padding:10px 16px;border-radius:14px;border:1px solid rgba(201,168,106,.32);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition)}
       .node-popover .popover-actions button.accent{background:linear-gradient(135deg,rgba(201,168,106,.24),rgba(170,140,84,.28));color:var(--bg-void)}
       .node-popover .popover-actions button:hover{border-color:rgba(227,198,139,.6)}
       .node-popover.disabled{pointer-events:none;opacity:.6}
       .node-context-menu{position:fixed;z-index:150;min-width:180px;padding:12px;margin:0;list-style:none;border-radius:18px;border:1px solid rgba(201,168,106,.32);background:linear-gradient(180deg,rgba(21,26,30,.96),rgba(12,16,18,.92));box-shadow:0 22px 48px rgba(0,0,0,.6);display:grid;gap:8px}
       .node-context-menu[hidden]{display:none!important}
-      .node-context-menu button{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78);color:var(--text-strong);font:600 13px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition)}
+      .node-context-menu button{padding:10px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78);color:var(--text-strong);font:600 13px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition)}
       .node-context-menu button:hover{border-color:rgba(201,168,106,.6);background:rgba(201,168,106,.12);color:var(--gold-400)}
       .node-context-menu[data-mode="sheet"]{left:50%!important;bottom:0!important;top:auto!important;transform:translateX(-50%);width:calc(100% - 24px);max-width:none;border-radius:20px 20px 0 0;padding:16px 16px 28px;gap:12px}
       .node-context-menu[data-mode="sheet"] button{width:100%}
       .relation-context-menu{position:fixed;z-index:160;min-width:160px;padding:10px;margin:0;border-radius:16px;border:1px solid rgba(75,195,209,.32);background:rgba(10,16,20,.94);box-shadow:0 18px 38px rgba(0,0,0,.55);display:grid;gap:8px}
       .relation-context-menu[hidden]{display:none!important}
-      .relation-context-menu button{padding:8px 12px;border-radius:12px;border:1px solid rgba(75,195,209,.28);background:rgba(12,18,24,.88);color:rgba(191,242,255,.92);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition)}
+      .relation-context-menu button{padding:8px 12px;border-radius:12px;border:1px solid rgba(75,195,209,.28);background:rgba(12,18,24,.88);color:rgba(191,242,255,.92);font:600 12px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background-color var(--transition)}
       .relation-context-menu button:hover{border-color:rgba(75,195,209,.6);background:rgba(75,195,209,.16);color:#e9fcff}
       .mind-settings{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:20px;z-index:130;background:rgba(5,6,8,.6);backdrop-filter:blur(8px)}
       .mind-settings[aria-hidden="false"]{display:flex}
       .mind-settings .settings-panel{background:linear-gradient(180deg,rgba(21,26,30,.96),rgba(12,16,18,.9));border:1px solid rgba(201,168,106,.32);border-radius:22px;box-shadow:0 32px 60px rgba(0,0,0,.65);padding:20px 22px;display:grid;gap:16px;min-width:280px;max-width:360px}
-      .mind-settings h3{margin:0;font:600 16px/1 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.14em;text-transform:uppercase}
-      .mind-settings label{display:flex;align-items:center;gap:10px;color:var(--text-strong);font:500 14px/1.4 'Noto Sans SC','Inter',sans-serif}
+      .mind-settings h3{margin:0;font:600 16px/1 var(--font-serif);color:var(--gold-400);letter-spacing:.14em;text-transform:uppercase}
+      .mind-settings label{display:flex;align-items:center;gap:10px;color:var(--text-strong);font:500 14px/1.4 var(--font-sans)}
       .mind-settings .settings-panel header{display:flex;align-items:center;justify-content:space-between;gap:12px}
       .mind-settings .settings-panel button.close{width:32px;height:32px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:none;color:var(--gold-400);cursor:pointer}
       .mind-settings .settings-panel button.close:hover{border-color:var(--gold-500)}
       .mind-settings .settings-actions{display:flex;justify-content:flex-end;gap:10px}
-      .mind-settings .settings-actions button{padding:10px 14px;border-radius:14px;border:1px solid rgba(201,168,106,.3);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer}
+      .mind-settings .settings-actions button{padding:10px 14px;border-radius:14px;border:1px solid rgba(201,168,106,.3);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 12px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer}
       .mind-attachment-backdrop{position:fixed;inset:0;display:none;align-items:stretch;justify-content:flex-end;padding:24px;background:rgba(6,8,10,.72);backdrop-filter:blur(16px);z-index:150}
       .mind-attachment-backdrop[data-open="true"]{display:flex}
       .mind-attachment-panel{width:min(520px,100%);max-width:520px;height:100%;display:flex;flex-direction:column;gap:16px;padding:22px 20px;border-radius:24px;background:linear-gradient(165deg,rgba(21,26,30,.96),rgba(12,16,18,.92));border:1px solid rgba(201,168,106,.36);box-shadow:0 32px 68px rgba(0,0,0,.65),0 0 32px rgba(227,198,139,.18);position:relative}
       .mind-attachment-panel header{display:flex;flex-direction:column;gap:10px}
       .mind-attachment-title{display:flex;align-items:center;justify-content:space-between;gap:12px}
-      .mind-attachment-title h3{margin:0;font:600 18px/1 'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
+      .mind-attachment-title h3{margin:0;font:600 18px/1 var(--font-serif);color:var(--gold-400);letter-spacing:.16em;text-transform:uppercase}
       .mind-attachment-close{width:32px;height:32px;border-radius:999px;border:1px solid rgba(201,168,106,.32);background:none;color:var(--gold-400);cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px;transition:border-color var(--transition),transform var(--transition)}
       .mind-attachment-close:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
-      .mind-attachment-summary{color:var(--text-muted);font:12px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
+      .mind-attachment-summary{color:var(--text-muted);font:12px/1.6 var(--font-sans);letter-spacing:.1em}
       .mind-attachment-controls{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
       .mind-attachment-filters{display:flex;flex-wrap:wrap;gap:8px}
-      .mind-attachment-filter{padding:6px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78);color:var(--text-dim);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background var(--transition),color var(--transition)}
+      .mind-attachment-filter{padding:6px 12px;border-radius:999px;border:1px solid rgba(201,168,106,.28);background:rgba(21,26,30,.78);color:var(--text-dim);font:600 11px/1 var(--font-sans);letter-spacing:.14em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),background var(--transition),color var(--transition)}
       .mind-attachment-filter[data-active="true"]{border-color:rgba(227,198,139,.6);background:rgba(227,198,139,.14);color:var(--gold-400)}
-      .mind-attachment-sort{display:flex;align-items:center;gap:8px;color:var(--text-muted);font:12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
-      .mind-attachment-sort select{padding:8px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.82);color:var(--text-strong);font:600 12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .mind-attachment-sort{display:flex;align-items:center;gap:8px;color:var(--text-muted);font:12px/1.4 var(--font-sans);letter-spacing:.08em}
+      .mind-attachment-sort select{padding:8px 12px;border-radius:12px;border:1px solid rgba(201,168,106,.32);background:rgba(15,19,22,.82);color:var(--text-strong);font:600 12px/1 var(--font-sans);letter-spacing:.08em}
       .mind-attachment-body{flex:1 1 auto;display:flex;flex-direction:column;gap:16px;min-height:0}
       .mind-attachment-list{position:relative;overflow:auto;border-radius:18px;border:1px solid rgba(201,168,106,.24);background:rgba(12,16,18,.78);box-shadow:inset 0 0 22px rgba(0,0,0,.45);padding:12px;display:grid;gap:10px;flex:1 1 auto;min-height:0}
       .mind-attachment-list::-webkit-scrollbar{width:8px}
@@ -344,27 +343,27 @@
       .mind-attachment-content{display:grid;gap:12px;min-width:0}
       .mind-attachment-header{display:flex;align-items:flex-start;gap:12px;flex-wrap:wrap}
       .mind-attachment-info{display:grid;gap:8px;min-width:0}
-      .mind-attachment-name{font:600 14px/1.5 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);letter-spacing:.04em;overflow-wrap:anywhere;word-break:break-all;flex:1 1 auto;min-width:0}
-      .mind-attachment-meta{display:flex;flex-wrap:wrap;gap:8px;color:var(--text-muted);font:11px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em;text-transform:uppercase}
+      .mind-attachment-name{font:600 14px/1.5 var(--font-sans);color:var(--text-strong);letter-spacing:.04em;overflow-wrap:anywhere;word-break:break-all;flex:1 1 auto;min-width:0}
+      .mind-attachment-meta{display:flex;flex-wrap:wrap;gap:8px;color:var(--text-muted);font:11px/1.4 var(--font-sans);letter-spacing:.1em;text-transform:uppercase}
       .mind-attachment-attrs{display:flex;flex-wrap:wrap;gap:12px;align-items:center}
       .mind-attachment-tag{padding:2px 8px;border-radius:999px;border:1px solid rgba(201,168,106,.22);background:rgba(21,26,30,.82)}
       .mind-attachment-node{color:var(--gold-400);cursor:pointer;text-decoration:none}
       .mind-attachment-node:hover{text-decoration:underline}
-      .mind-attachment-size{color:var(--text-dim);font:12px/1.3 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
-      .mind-attachment-time{color:var(--text-muted);font:11px/1.3 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .mind-attachment-size{color:var(--text-dim);font:12px/1.3 var(--font-sans);letter-spacing:.08em}
+      .mind-attachment-time{color:var(--text-muted);font:11px/1.3 var(--font-sans);letter-spacing:.08em}
       .mind-attachment-actions{display:flex;gap:6px;flex-wrap:wrap;margin-left:auto;justify-content:flex-end}
-      .mind-attachment-actions button{padding:6px 10px;border-radius:10px;border:1px solid rgba(201,168,106,.3);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em;text-transform:uppercase;cursor:pointer}
+      .mind-attachment-actions button{padding:6px 10px;border-radius:10px;border:1px solid rgba(201,168,106,.3);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 11px/1 var(--font-sans);letter-spacing:.1em;text-transform:uppercase;cursor:pointer}
       .mind-attachment-actions button:hover{border-color:rgba(227,198,139,.55)}
       .mind-attachment-actions button.danger{color:#fca5a5;border-color:rgba(209,75,75,.5)}
-      .mind-attachment-empty{padding:24px;border-radius:18px;border:1px dashed rgba(201,168,106,.28);background:rgba(12,16,18,.72);text-align:center;color:var(--text-muted);font:12px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .mind-attachment-empty{padding:24px;border-radius:18px;border:1px dashed rgba(201,168,106,.28);background:rgba(12,16,18,.72);text-align:center;color:var(--text-muted);font:12px/1.6 var(--font-sans);letter-spacing:.08em}
       .mind-attachment-footer{display:flex;flex-wrap:wrap;gap:12px;align-items:center;justify-content:space-between}
-      .mind-attachment-selection-info{color:var(--text-dim);font:12px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .mind-attachment-selection-info{color:var(--text-dim);font:12px/1.6 var(--font-sans);letter-spacing:.08em}
       .mind-attachment-bulk{display:flex;flex-wrap:wrap;gap:10px}
-      .mind-attachment-bulk button{padding:8px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.34);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 11px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),transform var(--transition)}
+      .mind-attachment-bulk button{padding:8px 14px;border-radius:12px;border:1px solid rgba(201,168,106,.34);background:rgba(21,26,30,.78);color:var(--gold-400);font:600 11px/1 var(--font-sans);letter-spacing:.12em;text-transform:uppercase;cursor:pointer;transition:border-color var(--transition),transform var(--transition)}
       .mind-attachment-bulk button:hover{border-color:rgba(227,198,139,.6);transform:translateY(-1px)}
       .mind-attachment-bulk button.danger{color:#fca5a5;border-color:rgba(209,75,75,.5)}
-      .mind-attachment-list .load-more{padding:12px;border-radius:14px;border:1px dashed rgba(201,168,106,.28);color:var(--text-muted);text-align:center;font:11px/1.4 'Inter','Noto Sans SC',sans-serif;text-transform:uppercase;letter-spacing:.12em}
-      .mind-attachment-alert{color:#fca5a5;font:12px/1.6 'Inter','Noto Sans SC',sans-serif}
+      .mind-attachment-list .load-more{padding:12px;border-radius:14px;border:1px dashed rgba(201,168,106,.28);color:var(--text-muted);text-align:center;font:11px/1.4 var(--font-sans);text-transform:uppercase;letter-spacing:.12em}
+      .mind-attachment-alert{color:#fca5a5;font:12px/1.6 var(--font-sans)}
       @media (max-width:720px){
         .mind-attachment-backdrop{padding:16px}
         .mind-attachment-panel{width:100%;border-radius:20px;height:100%;max-height:100svh}

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -6,9 +6,6 @@
     <title>新建备忘录</title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Inter:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;600;700&family=Noto+Serif+SC:wght@500;600;700&display=swap" rel="stylesheet">
     <style>
       :root{
         --bg-void:#0A0C0E;
@@ -50,9 +47,11 @@
         --danger-soft:rgba(209,75,75,.35);
         --grid-size:64px;
         --transition:var(--t) var(--ease);
+        --font-sans:'Inter','Source Han Sans','Noto Sans SC','PingFang SC','Microsoft YaHei','Helvetica Neue',Arial,sans-serif;
+        --font-serif:'Noto Serif SC','Source Han Serif SC','Songti SC','STSong','serif';
       }
       *,*::before,*::after{box-sizing:border-box}
-      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.65 'Source Han Sans','Noto Sans SC','Inter','Microsoft YaHei',sans-serif;letter-spacing:.01em;position:relative;overflow-x:hidden}
+      html,body{margin:0;min-height:100vh;color:var(--text-strong);background:var(--bg-void);font:16px/1.65 var(--font-sans);letter-spacing:.01em;position:relative;overflow-x:hidden}
       body{background:
         radial-gradient(1200px 700px at 70% -10%,rgba(227,198,139,.06),transparent 60%),
         linear-gradient(120deg,rgba(201,168,106,.08),transparent 30%,rgba(201,168,106,.06) 70%,transparent 90%),
@@ -71,19 +70,19 @@
       }
       .scanlines{position:fixed;inset:0;pointer-events:none;z-index:-1;background:linear-gradient(to bottom,rgba(75,195,209,.14) 0,transparent 4px);background-size:100% 6px;opacity:.18}
       a{color:inherit;text-decoration:none}
-      h1,h2,h3,h4{font-family:'Cinzel','Noto Serif SC',serif;color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
+      h1,h2,h3,h4{font-family:var(--font-serif);color:var(--gold-400);letter-spacing:-0.5px;text-transform:uppercase}
       .wrap{max-width:1180px;margin:0 auto;padding:32px 24px 64px;position:relative;z-index:0}
       .wrap::before{content:"";position:absolute;inset:16px;border-radius:var(--r-lg);border:1px dashed rgba(201,168,106,.18);opacity:.65;pointer-events:none}
       .card{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.92));border:1px solid rgba(201,168,106,.28);border-radius:var(--r-lg);padding:24px;box-shadow:var(--shadow-1);backdrop-filter:blur(14px)}
       .card::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-lg) - 4px);box-shadow:inset 0 0 0 1px rgba(227,198,139,.18),inset 0 0 34px rgba(227,198,139,.08);pointer-events:none;opacity:.9}
-      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(227,198,139,.65);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.62));color:#1b1306;cursor:pointer;text-transform:uppercase;font:600 13px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 14px 32px rgba(227,198,139,.25),0 0 24px rgba(227,198,139,.18);overflow:hidden}
+      .btn{position:relative;display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:var(--r-sm);border:1px solid rgba(227,198,139,.65);background:linear-gradient(135deg,rgba(227,198,139,.82),rgba(170,140,84,.62));color:#1b1306;cursor:pointer;text-transform:uppercase;font:600 13px/1.2 var(--font-sans);letter-spacing:.12em;transition:transform var(--transition),box-shadow var(--transition),border-color var(--transition);box-shadow:0 14px 32px rgba(227,198,139,.25),0 0 24px rgba(227,198,139,.18);overflow:hidden}
       .btn::after{content:none}
       .btn:hover{transform:translateY(-2px);box-shadow:0 18px 36px rgba(227,198,139,.3),0 0 28px rgba(227,198,139,.24)}
       .btn:active{transform:translateY(0);box-shadow:0 8px 20px rgba(227,198,139,.22)}
       .btn.acc{background:linear-gradient(135deg,rgba(227,198,139,.92),rgba(201,168,106,.72));color:#120d05}
       .btn:focus-visible{outline:2px solid var(--accent-cyan);outline-offset:3px;box-shadow:0 0 0 2px rgba(227,198,139,.25)}
       .row{display:grid;grid-template-columns:2fr 1fr auto;gap:16px;margin-bottom:20px;align-items:center}
-      .row input,.row select{padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 15px/1.4 'Noto Sans SC','Inter',sans-serif;letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
+      .row input,.row select{padding:12px 14px;border-radius:var(--r-sm);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.7);color:var(--text-strong);font:500 15px/1.4 var(--font-sans);letter-spacing:.02em;transition:border-color var(--transition),box-shadow var(--transition)}
       .row input::placeholder{color:var(--text-muted)}
       .row input:focus,.row select:focus{border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.16),inset 0 0 0 1px rgba(227,198,139,.22);outline:none}
       .split{display:grid;grid-template-columns:minmax(320px,1fr) minmax(320px,1fr);gap:24px;align-items:start}
@@ -93,42 +92,42 @@
       }
       .editbox,.preview{position:relative;background:linear-gradient(180deg,rgba(21,26,30,.88),rgba(15,19,22,.92));border:1px solid rgba(201,168,106,.28);border-radius:var(--r-md);padding:18px;min-height:280px;box-shadow:var(--shadow-1)}
       .editbox::before,.preview::before{content:"";position:absolute;inset:10px;border-radius:calc(var(--r-md) - 4px);border:1px solid rgba(201,168,106,.18);opacity:.6;pointer-events:none}
-      .editbox textarea{width:100%;min-height:260px;padding:14px;border-radius:var(--r-md);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.82);color:var(--text-strong);font:500 15px/1.6 'Noto Sans SC','Inter',sans-serif;letter-spacing:.03em;resize:vertical;transition:border-color var(--transition),box-shadow var(--transition)}
+      .editbox textarea{width:100%;min-height:260px;padding:14px;border-radius:var(--r-md);border:1px solid rgba(201,168,106,.28);background:rgba(12,16,18,.82);color:var(--text-strong);font:500 15px/1.6 var(--font-sans);letter-spacing:.03em;resize:vertical;transition:border-color var(--transition),box-shadow var(--transition)}
       .editbox textarea::placeholder{color:var(--text-muted)}
       .editbox textarea:focus{outline:none;border-color:var(--gold-500);box-shadow:0 0 0 3px rgba(227,198,139,.16),inset 0 0 0 1px rgba(227,198,139,.24)}
       .preview{max-height:60vh;overflow:auto;background-image:linear-gradient(120deg,rgba(201,168,106,.06),transparent 55%)}
       .preview::-webkit-scrollbar{width:8px}
       .preview::-webkit-scrollbar-thumb{background:rgba(201,168,106,.28);border-radius:999px}
-      .md-body{color:var(--text-dim);font:400 15px/1.75 'Noto Sans SC','Inter',sans-serif}
+      .md-body{color:var(--text-dim);font:400 15px/1.75 var(--font-sans)}
       .md-body img{max-width:100%;height:auto;border:1px solid rgba(201,168,106,.32);border-radius:var(--r-sm);box-shadow:0 16px 34px rgba(0,0,0,.55),0 0 24px rgba(227,198,139,.12)}
       .attachment-panel{display:flex;flex-direction:column;gap:16px}
       .attachment-panel-header{display:flex;align-items:center;justify-content:space-between;gap:12px}
-      .attachment-panel-title{font:600 14px/1.2 'Inter','Noto Sans SC',sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400)}
-      .attachment-panel-meta{color:var(--text-muted);font:12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.1em}
-      .attachment-empty{padding:18px;border:1px dashed rgba(201,168,106,.28);border-radius:16px;background:rgba(12,16,18,.66);color:var(--text-muted);text-align:center;font:500 13px/1.6 'Inter','Noto Sans SC',sans-serif;letter-spacing:.06em}
+      .attachment-panel-title{font:600 14px/1.2 var(--font-sans);letter-spacing:.16em;text-transform:uppercase;color:var(--gold-400)}
+      .attachment-panel-meta{color:var(--text-muted);font:12px/1.4 var(--font-sans);letter-spacing:.1em}
+      .attachment-empty{padding:18px;border:1px dashed rgba(201,168,106,.28);border-radius:16px;background:rgba(12,16,18,.66);color:var(--text-muted);text-align:center;font:500 13px/1.6 var(--font-sans);letter-spacing:.06em}
       .attachment-list{display:grid;gap:12px}
       .attachment-row{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap;padding:14px 16px;border-radius:16px;border:1px solid rgba(201,168,106,.26);background:rgba(12,16,18,.78);box-shadow:var(--shadow-1)}
       .attachment-main{display:flex;align-items:center;gap:12px;min-width:0;flex:1}
       .attachment-icon{font-size:26px;line-height:1}
       .attachment-info{display:grid;gap:4px;min-width:0}
-      .attachment-name{font:600 14px/1.4 'Inter','Noto Sans SC',sans-serif;color:var(--text-strong);letter-spacing:.04em;word-break:break-all}
-      .attachment-detail{color:var(--text-muted);font:12px/1.4 'Inter','Noto Sans SC',sans-serif;letter-spacing:.08em}
+      .attachment-name{font:600 14px/1.4 var(--font-sans);color:var(--text-strong);letter-spacing:.04em;word-break:break-all}
+      .attachment-detail{color:var(--text-muted);font:12px/1.4 var(--font-sans);letter-spacing:.08em}
       .attachment-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
       .attachment-actions form{margin:0}
-      .att-meta{color:var(--text-muted);font:12px/1 'Inter','Noto Sans SC',sans-serif;letter-spacing:.12em}
+      .att-meta{color:var(--text-muted);font:12px/1 var(--font-sans);letter-spacing:.12em}
       .timeline{position:relative;margin-top:20px;margin-left:16px;padding-left:32px;color:var(--text-muted)}
       .timeline::before{content:"";position:absolute;left:12px;top:0;bottom:0;width:2px;background:linear-gradient(180deg,rgba(201,168,106,.6),rgba(201,168,106,.1));box-shadow:0 0 18px rgba(227,198,139,.28)}
       .tl-item{position:relative;margin:14px 0;padding:16px 18px 18px 24px;border:1px solid rgba(201,168,106,.32);border-radius:var(--r-md);background:linear-gradient(180deg,rgba(21,26,30,.9),rgba(15,19,22,.92));box-shadow:var(--shadow-1)}
       .tl-item::before{content:"";position:absolute;inset:8px;border-radius:calc(var(--r-md) - 4px);border:1px dashed rgba(201,168,106,.16);opacity:.6;pointer-events:none}
       .tl-item .tl-dot{position:absolute;left:-30px;top:20px;width:16px;height:16px;border-radius:50%;background:linear-gradient(135deg,rgba(201,168,106,.92),rgba(170,140,84,.9));box-shadow:0 0 24px rgba(227,198,139,.32)}
       .tl-item .tl-dot::after{content:"";position:absolute;inset:-6px;border-radius:inherit;border:1px dashed rgba(201,168,106,.45);opacity:.85;box-shadow:0 0 16px rgba(227,198,139,.28)}
-      .tl-head{display:flex;gap:12px;align-items:center;color:var(--text-strong);font-family:'Inter','Noto Sans SC',sans-serif}
+      .tl-head{display:flex;gap:12px;align-items:center;color:var(--text-strong);font-family:var(--font-sans)}
       .tl-item.done .tl-head div,.tl-item.done .md-body{opacity:.72;text-decoration:line-through}
       .tl-item.done{background:linear-gradient(160deg,rgba(36,194,160,.18),rgba(15,22,20,.92));border-color:rgba(36,194,160,.42);box-shadow:0 0 28px rgba(36,194,160,.28)}
       .drag{cursor:grab;color:var(--text-muted);user-select:none;font-size:18px}
-      .ts{color:var(--text-dim);font:12px/1 'Inter','Noto Sans SC',sans-serif;margin-left:6px;letter-spacing:.12em}
-      details summary{cursor:pointer;color:var(--text-muted);text-transform:uppercase;letter-spacing:.16em;font:500 12px/1.4 'Inter','Noto Sans SC',sans-serif}
-      .save-tip{color:var(--gold-400);font:12px/1 'Inter','Noto Sans SC',sans-serif;display:none;margin-left:10px;text-transform:uppercase;letter-spacing:.18em}
+      .ts{color:var(--text-dim);font:12px/1 var(--font-sans);margin-left:6px;letter-spacing:.12em}
+      details summary{cursor:pointer;color:var(--text-muted);text-transform:uppercase;letter-spacing:.16em;font:500 12px/1.4 var(--font-sans)}
+      .save-tip{color:var(--gold-400);font:12px/1 var(--font-sans);display:none;margin-left:10px;text-transform:uppercase;letter-spacing:.18em}
       .save-tip.dirty{color:var(--accent-crimson)}
       .save-tip.show{display:inline-block}
       .placeholder-muted{color:var(--text-muted)}


### PR DESCRIPTION
## Summary
- add helpers to reuse mindmap asset metadata and avoid redundant queries during cleanup and deletion flows
- paginate memo list queries and render navigation controls on the homepage
- remove Google Fonts usage in memo views and tighten CSP font allowances to rely on local stacks

## Testing
- php -l memo.php
- php -l config/security.php
- php -l resources/views/memo/index.phtml
- php -l resources/views/memo/item.phtml
- php -l resources/views/memo/new.phtml
- php -l resources/views/memo/map_edit.phtml
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68e8f56155648328ba16a30d8d5107b4