### PR TITLE
feat: support subdirectory deployment

### DIFF
--- a/app/Memo/Legacy/Environment.php
+++ b/app/Memo/Legacy/Environment.php
@@ -11,13 +11,20 @@ final class Environment
     private static ?RuntimeConfig $runtimeConfig = null;
     private static ?string $csrfToken = null;
     private static bool $securityHeadersApplied = false;
+    private static string $basePath = '';
 
-    public static function bootstrap(Config $config, string $csrfToken, RuntimeConfig $runtimeConfig): void
+    public static function bootstrap(
+        Config $config,
+        string $csrfToken,
+        RuntimeConfig $runtimeConfig,
+        string $basePath = ''
+    ): void
     {
         self::$config = $config;
         self::$csrfToken = $csrfToken;
         self::$runtimeConfig = $runtimeConfig;
         self::$securityHeadersApplied = false;
+        self::$basePath = self::normalizeBasePath($basePath);
     }
 
     public static function config(): ?Config
@@ -47,5 +54,21 @@ final class Environment
     public static function markSecurityHeadersApplied(): void
     {
         self::$securityHeadersApplied = true;
+    }
+
+    public static function basePath(): string
+    {
+        return self::$basePath;
+    }
+
+    private static function normalizeBasePath(string $basePath): string
+    {
+        if ($basePath === '' || $basePath === '/') {
+            return '';
+        }
+
+        $normalized = '/' . ltrim($basePath, '/');
+
+        return rtrim($normalized, '/');
     }
 }

--- a/app/Memo/Legacy/LegacyMemoRunner.php
+++ b/app/Memo/Legacy/LegacyMemoRunner.php
@@ -18,7 +18,7 @@ final class LegacyMemoRunner
     public function handle(Request $request, string $csrfToken): void
     {
         $runtimeConfig = RuntimeConfig::fromConfig($this->config, $this->projectRoot);
-        Environment::bootstrap($this->config, $csrfToken, $runtimeConfig);
+        Environment::bootstrap($this->config, $csrfToken, $runtimeConfig, $request->basePath());
 
         require $this->projectRoot . '/memo.php';
     }

--- a/memo.php
+++ b/memo.php
@@ -26,6 +26,26 @@ function memo_start_session(): void {
   session_start();
 }
 
+function memo_base_path(): string {
+  $basePath = MemoEnvironment::basePath();
+  if ($basePath === '/' || $basePath === '') {
+    return '';
+  }
+
+  return $basePath;
+}
+
+function memo_asset_url(string $path): string {
+  $normalized = '/' . ltrim($path, '/');
+  $basePath = memo_base_path();
+
+  if ($basePath === '') {
+    return $normalized;
+  }
+
+  return $basePath . $normalized;
+}
+
 memo_start_session();
 mb_internal_encoding('UTF-8');
 

--- a/resources/views/memo/index.phtml
+++ b/resources/views/memo/index.phtml
@@ -6,9 +6,9 @@
 <title>自适应备忘录 · 单文件</title>
 <meta name="color-scheme" content="dark"/>
 <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-<link rel="stylesheet" href="/assets/css/memo-common.css"/>
-<link rel="stylesheet" href="/assets/css/memo-index.css"/>
-<script src="/assets/js/csrf.js" defer></script>
+<link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-common.css'); ?>"/>
+<link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-index.css'); ?>"/>
+<script src="<?= memo_asset_url('assets/js/csrf.js'); ?>" defer></script>
 </head>
 <body>
   <div class="scanlines" aria-hidden="true"></div>
@@ -305,6 +305,6 @@
   </div>
 </div>
 <script>window.memoIndexConfig = Object.assign({}, window.memoIndexConfig, {currentCategoryFilter: <?php echo json_encode((string)$cat); ?>});</script>
-<script src="/assets/js/memo-index.js" defer></script>
+<script src="<?= memo_asset_url('assets/js/memo-index.js'); ?>" defer></script>
 </body>
 </html>

--- a/resources/views/memo/item.phtml
+++ b/resources/views/memo/item.phtml
@@ -6,9 +6,9 @@
     <title>详情 · <?php echo h($it['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="stylesheet" href="/assets/css/memo-common.css"/>
-<link rel="stylesheet" href="/assets/css/memo-item.css"/>
-    <script src="/assets/js/csrf.js" defer></script>
+    <link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-common.css'); ?>"/>
+    <link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-item.css'); ?>"/>
+    <script src="<?= memo_asset_url('assets/js/csrf.js'); ?>" defer></script>
 
   </head>
   <body>
@@ -185,6 +185,6 @@
         itemId: <?= (int)$it['id']; ?>
       });
     </script>
-    <script src="/assets/js/memo-item.js" defer></script>
+    <script src="<?= memo_asset_url('assets/js/memo-item.js'); ?>" defer></script>
   </body>
   </html>

--- a/resources/views/memo/map_edit.phtml
+++ b/resources/views/memo/map_edit.phtml
@@ -6,9 +6,9 @@
     <title>思维导图编辑器 · <?php echo h($mind['title']); ?></title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="stylesheet" href="/assets/css/memo-common.css"/>
-<link rel="stylesheet" href="/assets/css/memo-map-edit.css"/>
-    <script src="/assets/js/csrf.js" defer></script>
+    <link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-common.css'); ?>"/>
+    <link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-map-edit.css'); ?>"/>
+    <script src="<?= memo_asset_url('assets/js/csrf.js'); ?>" defer></script>
 
   </head>
   <body>
@@ -232,6 +232,6 @@
         initialAssetMeta: <?= json_encode($mindmapAssetsMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?>
       });
     </script>
-    <script src="/assets/js/memo-map-edit.js" defer></script>
+    <script src="<?= memo_asset_url('assets/js/memo-map-edit.js'); ?>" defer></script>
   </body>
   </html>

--- a/resources/views/memo/new.phtml
+++ b/resources/views/memo/new.phtml
@@ -6,9 +6,9 @@
     <title>新建备忘录</title>
     <meta name="color-scheme" content="dark"/>
     <meta name="csrf-token" content="<?= h(csrf_token()); ?>"/>
-    <link rel="stylesheet" href="/assets/css/memo-common.css"/>
-<link rel="stylesheet" href="/assets/css/memo-new.css"/>
-    <script src="/assets/js/csrf.js" defer></script>
+    <link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-common.css'); ?>"/>
+    <link rel="stylesheet" href="<?= memo_asset_url('assets/css/memo-new.css'); ?>"/>
+    <script src="<?= memo_asset_url('assets/js/csrf.js'); ?>" defer></script>
   </head>
   <body data-density="comfortable">
     <div class="scanlines" aria-hidden="true"></div>
@@ -69,6 +69,6 @@
         uploadAccept: <?= json_encode(memo_upload_accept_attribute()); ?>
       });
     </script>
-    <script src="/assets/js/memo-new.js" defer></script>
+    <script src="<?= memo_asset_url('assets/js/memo-new.js'); ?>" defer></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- capture the request base path in the legacy memo environment and expose helpers for prefixing asset URLs
- load memo CSS/JS assets through the new helper so they resolve when the app lives under a subdirectory

## Testing
- php -l app/Memo/Legacy/Environment.php
- php -l app/Memo/Legacy/LegacyMemoRunner.php
- php -l memo.php
- php -l resources/views/memo/index.phtml
- php -l resources/views/memo/item.phtml
- php -l resources/views/memo/map_edit.phtml
- php -l resources/views/memo/new.phtml
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68e98ac0d3008328b2a986b23b36d696