### PR TITLE
Ensure FormData CSRF appending works without has()

### DIFF
--- a/public/assets/js/csrf.js
+++ b/public/assets/js/csrf.js
@@ -15,8 +15,21 @@
       }
       init.headers=headers;
       const body=init.body;
-      if(token && body instanceof FormData && !body.has('_csrf')){
-        body.append('_csrf',token);
+      if(token && body instanceof FormData){
+        let shouldAppend=true;
+        if(typeof body.has==='function'){
+          shouldAppend=!body.has('_csrf');
+        }else if(typeof body.entries==='function'){
+          for(const [key] of body.entries()){
+            if(key==='_csrf'){
+              shouldAppend=false;
+              break;
+            }
+          }
+        }
+        if(shouldAppend){
+          body.append('_csrf',token);
+        }
       }
       return originalFetch.call(this,input,init);
     };


### PR DESCRIPTION
## Summary
- guard against FormData implementations missing the has() method before checking for an existing CSRF token
- fall back to scanning entries or appending the token directly so POST requests from older browsers include _csrf

## Testing
- php tests/run.php
- npx --yes eslint@8 --no-eslintrc --env browser --parser-options ecmaVersion:2020 public/assets/js/csrf.js

------
https://chatgpt.com/codex/tasks/task_e_68ee83d5410c832899425d44e3cf96f2