### PR TITLE
feat: 自动判定 session cookie secure 标志

### DIFF
--- a/app/Support/HttpSchemeDetector.php
+++ b/app/Support/HttpSchemeDetector.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class HttpSchemeDetector
+{
+    /**
+     * @param array<string, mixed> $server
+     */
+    public static function isHttps(array $server): bool
+    {
+        $https = $server['HTTPS'] ?? '';
+        if (is_string($https) && $https !== '' && strtolower($https) !== 'off') {
+            return true;
+        }
+
+        foreach (['HTTP_X_FORWARDED_PROTO', 'HTTP_X_FORWARDED_SCHEME'] as $header) {
+            if (self::isForwardedProtoHttps($server[$header] ?? null)) {
+                return true;
+            }
+        }
+
+        foreach (['HTTP_X_FORWARDED_SSL', 'HTTP_FRONT_END_HTTPS'] as $header) {
+            $value = $server[$header] ?? null;
+            if (is_string($value) && strtolower(trim($value)) === 'on') {
+                return true;
+            }
+        }
+
+        $forwarded = $server['HTTP_FORWARDED'] ?? null;
+        if (is_string($forwarded) && $forwarded !== '') {
+            foreach (explode(',', $forwarded) as $part) {
+                foreach (explode(';', $part) as $directive) {
+                    $pair = explode('=', trim($directive), 2);
+                    if (count($pair) !== 2) {
+                        continue;
+                    }
+                    if (strtolower($pair[0]) === 'proto' && strtolower(trim($pair[1], " \"'")) === 'https') {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static function isForwardedProtoHttps(mixed $value): bool
+    {
+        if (!is_string($value) || $value === '') {
+            return false;
+        }
+
+        $first = explode(',', $value)[0] ?? '';
+        return strtolower(trim($first)) === 'https';
+    }
+}

--- a/app/Support/SecurityHeaders.php
+++ b/app/Support/SecurityHeaders.php
@@ -41,7 +41,7 @@ final class SecurityHeaders
 
         $hsts = $settings['hsts'] ?? null;
         if (is_array($hsts) && !empty($hsts['enable'])) {
-            if (self::isHttps($_SERVER)) {
+            if (HttpSchemeDetector::isHttps($_SERVER)) {
                 $maxAge = (int)($hsts['max_age'] ?? 0);
                 $directives = ['max-age=' . max(0, $maxAge)];
                 if (!empty($hsts['include_subdomains'])) {
@@ -76,56 +76,5 @@ final class SecurityHeaders
         }
 
         $GLOBALS['_legacy_security_headers_applied'] = true;
-    }
-
-    /**
-     * @param array<string, mixed> $server
-     */
-    private static function isHttps(array $server): bool
-    {
-        $https = $server['HTTPS'] ?? '';
-        if (is_string($https) && $https !== '' && strtolower($https) !== 'off') {
-            return true;
-        }
-
-        foreach (['HTTP_X_FORWARDED_PROTO', 'HTTP_X_FORWARDED_SCHEME'] as $header) {
-            if (self::isForwardedProtoHttps($server[$header] ?? null)) {
-                return true;
-            }
-        }
-
-        foreach (['HTTP_X_FORWARDED_SSL', 'HTTP_FRONT_END_HTTPS'] as $header) {
-            $value = $server[$header] ?? null;
-            if (is_string($value) && strtolower(trim($value)) === 'on') {
-                return true;
-            }
-        }
-
-        $forwarded = $server['HTTP_FORWARDED'] ?? null;
-        if (is_string($forwarded) && $forwarded !== '') {
-            foreach (explode(',', $forwarded) as $part) {
-                foreach (explode(';', $part) as $directive) {
-                    $pair = explode('=', trim($directive), 2);
-                    if (count($pair) !== 2) {
-                        continue;
-                    }
-                    if (strtolower($pair[0]) === 'proto' && strtolower(trim($pair[1], " \"'")) === 'https') {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static function isForwardedProtoHttps(mixed $value): bool
-    {
-        if (!is_string($value) || $value === '') {
-            return false;
-        }
-
-        $first = explode(',', $value)[0] ?? '';
-        return strtolower(trim($first)) === 'https';
     }
 }

--- a/app/Support/SessionConfigurator.php
+++ b/app/Support/SessionConfigurator.php
@@ -22,7 +22,7 @@ final class SessionConfigurator
         $cookieParams = session_get_cookie_params();
 
         if (array_key_exists('cookie_secure', $session)) {
-            $cookieParams['secure'] = (bool) $session['cookie_secure'];
+            $cookieParams['secure'] = self::resolveCookieSecure($session['cookie_secure']);
         }
 
         if (array_key_exists('cookie_httponly', $session)) {
@@ -53,5 +53,29 @@ final class SessionConfigurator
         if (isset($session['cookie_name']) && is_string($session['cookie_name']) && $session['cookie_name'] !== '') {
             session_name($session['cookie_name']);
         }
+    }
+
+    private static function resolveCookieSecure(mixed $value): bool
+    {
+        if (is_string($value)) {
+            $normalized = strtolower(trim($value));
+            if ($normalized === 'auto') {
+                return HttpSchemeDetector::isHttps($_SERVER);
+            }
+
+            if (in_array($normalized, ['1', 'true', 'on', 'yes'], true)) {
+                return true;
+            }
+
+            if (in_array($normalized, ['0', 'false', 'off', 'no'], true)) {
+                return false;
+            }
+        }
+
+        if ($value === null) {
+            return false;
+        }
+
+        return (bool) $value;
     }
 }

--- a/config/security.php
+++ b/config/security.php
@@ -1,7 +1,7 @@
 <?php
 return [
     'session' => [
-        'cookie_secure' => true,
+        'cookie_secure' => (($value = getenv('SESSION_COOKIE_SECURE')) !== false) ? $value : 'auto',
         'cookie_httponly' => true,
         'cookie_samesite' => 'Lax',
         'cookie_name' => 'memo_session',


### PR DESCRIPTION
## Summary
- 为 session 配置新增基于环境变量的 cookie_secure 开关，默认启用自动判定
- 抽取 HttpSchemeDetector 复用 HTTPS 检测逻辑，并在会话配置与安全头中使用

## Testing
- php -l (all PHP files)
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ee868060388328bd61b71f6ea6d5de