### PR TITLE
Update portal to surface latest memo and mindmap info

### DIFF
--- a/app/Controllers/PortalController.php
+++ b/app/Controllers/PortalController.php
@@ -30,15 +30,14 @@ final class PortalController
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @return array<int, array{id:int,title:string,done:bool,updated_at:int|null,updated_label:string,updated_iso:string,url:string}>
      */
     private function loadTodoItems(PDO $pdo, string $memoUrl): array
     {
         $stmt = $pdo->prepare(
-            'SELECT items.id, items.title, items.done, items.updated_at, categories.name AS category_name
+            'SELECT items.id, items.title, items.done, items.updated_at
             FROM items
-            LEFT JOIN categories ON categories.id = items.category_id
-            ORDER BY items.done ASC, items.order_index ASC, items.updated_at DESC, items.id DESC
+            ORDER BY items.updated_at DESC, items.id DESC
             LIMIT 4'
         );
         $stmt->execute();
@@ -50,28 +49,17 @@ final class PortalController
         $result = [];
         foreach ($items as $row) {
             $done = (int)($row['done'] ?? 0) === 1;
-            $metaParts = [];
-            if (!$done) {
-                $categoryName = is_string($row['category_name'] ?? null) ? trim($row['category_name']) : '';
-                if ($categoryName !== '') {
-                    $metaParts[] = $categoryName;
-                }
-            } else {
-                $metaParts[] = '已完成';
-            }
-
             $updatedAt = isset($row['updated_at']) ? (int)$row['updated_at'] : null;
-            if ($updatedAt) {
-                $metaParts[] = '更新 ' . format_datetime($updatedAt);
-            }
-
-            $meta = implode(' · ', $metaParts);
+            $updatedLabel = $updatedAt ? '最近修改 ' . format_datetime($updatedAt) : '';
+            $updatedIso = $updatedAt ? date('c', $updatedAt) : '';
 
             $result[] = [
                 'id' => (int)($row['id'] ?? 0),
                 'title' => (string)($row['title'] ?? '未命名任务'),
                 'done' => $done,
-                'meta' => $meta,
+                'updated_at' => $updatedAt,
+                'updated_label' => $updatedLabel,
+                'updated_iso' => $updatedIso,
                 'url' => $memoUrl . '?view=item&id=' . ((int)($row['id'] ?? 0)),
             ];
         }
@@ -102,9 +90,10 @@ final class PortalController
         $result = [];
         foreach ($rows as $index => $row) {
             $statusMeta = $statusCycle[$index % count($statusCycle)];
-            $summary = $this->summariseMindmap($row['content'] ?? null);
+            $summaryData = $this->summariseMindmap($row['content'] ?? null);
             $updatedAt = isset($row['updated_at']) ? (int)$row['updated_at'] : null;
-            $meta = $updatedAt ? '更新 ' . format_datetime($updatedAt) : '暂无更新记录';
+            $updatedLabel = $updatedAt ? '最近修改 ' . format_datetime($updatedAt) : '';
+            $updatedIso = $updatedAt ? date('c', $updatedAt) : '';
 
             $result[] = [
                 'id' => (int)($row['id'] ?? 0),
@@ -112,8 +101,12 @@ final class PortalController
                 'status' => $statusMeta['status'],
                 'status_label' => $statusMeta['label'],
                 'preview' => $statusMeta['preview'],
-                'summary' => $summary,
-                'meta' => $meta,
+                'summary' => $summaryData['summary'],
+                'nodes' => $summaryData['nodes'],
+                'node_count' => $summaryData['node_count'],
+                'updated_at' => $updatedAt,
+                'updated_label' => $updatedLabel,
+                'updated_iso' => $updatedIso,
                 'url' => $memoUrl . '?view=map_edit&id=' . ((int)($row['id'] ?? 0)),
             ];
         }
@@ -121,20 +114,35 @@ final class PortalController
         return $result;
     }
 
-    private function summariseMindmap(?string $payload): string
+    /**
+     * @return array{summary:string,nodes:array<int,string>,node_count:int}
+     */
+    private function summariseMindmap(?string $payload): array
     {
         if (!is_string($payload) || $payload === '') {
-            return '';
+            return [
+                'summary' => '',
+                'nodes' => [],
+                'node_count' => 0,
+            ];
         }
 
         $decoded = json_decode($payload, true);
         if (!is_array($decoded)) {
-            return '';
+            return [
+                'summary' => '',
+                'nodes' => [],
+                'node_count' => 0,
+            ];
         }
 
         $data = $decoded['data'] ?? null;
         if (!is_array($data)) {
-            return '';
+            return [
+                'summary' => '',
+                'nodes' => [],
+                'node_count' => 0,
+            ];
         }
 
         $topic = trim((string)($data['topic'] ?? ''));
@@ -153,7 +161,7 @@ final class PortalController
                 continue;
             }
             $childTopics[] = $childTopic;
-            if (count($childTopics) >= 2) {
+            if (count($childTopics) >= 3) {
                 break;
             }
         }
@@ -174,7 +182,11 @@ final class PortalController
             $summary = '节点 ' . $nodeCount;
         }
 
-        return $summary;
+        return [
+            'summary' => $summary,
+            'nodes' => $childTopics,
+            'node_count' => $nodeCount,
+        ];
     }
 
     /**

--- a/public/assets/portal/style.css
+++ b/public/assets/portal/style.css
@@ -1766,6 +1766,19 @@ body::after {
   letter-spacing: 0.26em;
 }
 
+.todo-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.todo-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
 .todo-text {
   color: var(--text-strong);
   text-decoration: none;
@@ -1782,8 +1795,7 @@ body::after {
   width: 10px;
   height: 10px;
   border: 1px solid rgba(255, 255, 255, 0.24);
-  margin-right: 14px;
-  vertical-align: middle;
+  margin-top: 6px;
   border-radius: 50%;
 }
 
@@ -1792,17 +1804,28 @@ body::after {
   box-shadow: 0 0 10px rgba(255, 59, 59, 0.35);
 }
 
-.todo-meta {
-  display: block;
-  margin-left: 24px;
-  margin-top: 4px;
-  font-size: 0.62rem;
+.todo-timestamp {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  font-size: 0.6rem;
   letter-spacing: 0.2em;
-  color: rgba(200, 206, 214, 0.65);
+  color: rgba(200, 206, 214, 0.68);
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
 .todo-empty .todo-text {
   color: var(--text-muted);
+}
+
+.todo-empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .module-footer {
@@ -1926,6 +1949,9 @@ body::after {
 }
 
 .map-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
   font-size: 0.6rem;
   letter-spacing: 0.24em;
   color: rgba(180, 184, 190, 0.72);
@@ -1937,6 +1963,48 @@ body::after {
   letter-spacing: 0.18em;
   color: rgba(200, 206, 214, 0.75);
   line-height: 1.6;
+}
+
+.map-card-nodes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  color: rgba(200, 206, 214, 0.75);
+}
+
+.map-card-node {
+  position: relative;
+  padding-left: 14px;
+  line-height: 1.6;
+}
+
+.map-card-node::before {
+  content: '▹';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--accent-red);
+  font-size: 0.7rem;
+}
+
+.map-card-timestamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(200, 206, 214, 0.78);
+}
+
+.map-card-count {
+  color: rgba(200, 206, 214, 0.68);
+  letter-spacing: 0.24em;
 }
 
 .map-preview {

--- a/resources/views/portal/index.phtml
+++ b/resources/views/portal/index.phtml
@@ -1,7 +1,7 @@
 <?php
 /**
- * @var array<int, array<string, mixed>> $todoItems
- * @var array<int, array<string, mixed>> $mindmaps
+ * @var array<int, array{id:int,title:string,done:bool,updated_at:int|null,updated_label:string,updated_iso:string,url:string}> $todoItems
+ * @var array<int, array{id:int,title:string,status:string,status_label:string,preview:string,summary:string,nodes:array<int,string>,node_count:int,updated_at:int|null,updated_label:string,updated_iso:string,url:string}> $mindmaps
  * @var callable(string):string $asset
  * @var string $memoUrl
  * @var string $mindmapUrl
@@ -238,14 +238,18 @@
               <ul class="todo-list">
                 <?php if ($todoItems !== []): ?>
                   <?php foreach ($todoItems as $item): ?>
-                    <li>
+                    <li class="todo-entry">
                       <span class="todo-indicator<?= $item['done'] ? ' done' : ''; ?>"></span>
-                      <a class="todo-text" href="<?= view_escape($item['url']); ?>">
-                        <?= view_escape($item['title']); ?>
-                      </a>
-                      <?php if ($item['meta'] !== ''): ?>
-                        <span class="todo-meta"><?= view_escape($item['meta']); ?></span>
-                      <?php endif; ?>
+                      <div class="todo-content">
+                        <a class="todo-text" href="<?= view_escape($item['url']); ?>">
+                          <?= view_escape($item['title']); ?>
+                        </a>
+                        <?php if ($item['updated_label'] !== ''): ?>
+                          <time class="todo-timestamp"<?php if ($item['updated_iso'] !== ''): ?> datetime="<?= view_escape($item['updated_iso']); ?>"<?php endif; ?>>
+                            <?= view_escape($item['updated_label']); ?>
+                          </time>
+                        <?php endif; ?>
+                      </div>
                     </li>
                   <?php endforeach; ?>
                 <?php else: ?>
@@ -311,11 +315,26 @@
                       </header>
                       <a class="map-card-body" href="<?= view_escape($map['url']); ?>">
                         <div class="map-preview <?= view_escape($map['preview']); ?>"></div>
-                        <?php if ($map['summary'] !== ''): ?>
+                        <?php if ($map['nodes'] !== []): ?>
+                          <ul class="map-card-nodes">
+                            <?php foreach ($map['nodes'] as $node): ?>
+                              <li class="map-card-node"><?= view_escape($node); ?></li>
+                            <?php endforeach; ?>
+                          </ul>
+                        <?php elseif ($map['summary'] !== ''): ?>
                           <div class="map-card-summary"><?= view_escape($map['summary']); ?></div>
                         <?php endif; ?>
                       </a>
-                      <footer class="map-card-meta"><?= view_escape($map['meta']); ?></footer>
+                      <footer class="map-card-meta">
+                        <?php if ($map['updated_label'] !== ''): ?>
+                          <time class="map-card-timestamp"<?php if ($map['updated_iso'] !== ''): ?> datetime="<?= view_escape($map['updated_iso']); ?>"<?php endif; ?>>
+                            <?= view_escape($map['updated_label']); ?>
+                          </time>
+                        <?php endif; ?>
+                        <?php if ($map['node_count'] > 0): ?>
+                          <span class="map-card-count">节点 <?= view_escape((string)$map['node_count']); ?></span>
+                        <?php endif; ?>
+                      </footer>
                     </article>
                   <?php endforeach; ?>
                 <?php else: ?>


### PR DESCRIPTION
## Summary
- adjust the portal controller to pull the newest memos and mindmaps and expose their timestamps and node details
- update the portal view so the to-do list shows last-modified memo times and mindmap cards list recent nodes while linking back to the legacy system
- refresh portal styles to support the new timestamp badges and node list presentation

## Testing
- php -l app/Controllers/PortalController.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68eeacea61a88328969f76d9af5c3503