### PR TITLE
Fix memo base path detection for subdirectory deployments

### DIFF
--- a/core/Request.php
+++ b/core/Request.php
@@ -139,12 +139,95 @@ class Request
 
     private function detectBasePath(array $server): string
     {
-        $scriptName = $server['SCRIPT_NAME'] ?? '';
-        if ($scriptName === '') {
+        $forwarded = $this->normalizeForwardedPrefix($server['HTTP_X_FORWARDED_PREFIX'] ?? null);
+        if ($forwarded !== '') {
+            return $forwarded;
+        }
+
+        $prefixCandidates = [
+            $server['BASE_URI'] ?? null,
+            $server['CONTEXT_PREFIX'] ?? null,
+        ];
+
+        foreach ($prefixCandidates as $candidate) {
+            $normalized = $this->normalizePrefixCandidate($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        $scriptCandidates = [
+            $server['SCRIPT_NAME'] ?? null,
+            $server['PHP_SELF'] ?? null,
+            $server['ORIG_SCRIPT_NAME'] ?? null,
+        ];
+
+        foreach ($scriptCandidates as $candidate) {
+            $normalized = $this->normalizeScriptCandidate($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function normalizeForwardedPrefix(mixed $value): string
+    {
+        if (!is_string($value)) {
             return '';
         }
 
-        $directory = str_replace('\\', '/', dirname($scriptName));
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $parts = array_map(static fn (string $part): string => trim($part), explode(',', $trimmed));
+        $parts = array_values(array_filter($parts, static fn (string $part): bool => $part !== ''));
+        if ($parts === []) {
+            return '';
+        }
+
+        return $this->normalizePrefixCandidate($parts[0]);
+    }
+
+    private function normalizePrefixCandidate(mixed $value): string
+    {
+        if (!is_string($value)) {
+            return '';
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '' || $trimmed === '/') {
+            return '';
+        }
+
+        $path = parse_url($trimmed, PHP_URL_PATH);
+        if (!is_string($path) || $path === '' || $path === '/') {
+            return '';
+        }
+
+        return '/' . trim($path, '/');
+    }
+
+    private function normalizeScriptCandidate(mixed $value): string
+    {
+        if (!is_string($value)) {
+            return '';
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return '';
+        }
+
+        $path = parse_url($trimmed, PHP_URL_PATH);
+        if (!is_string($path) || $path === '') {
+            return '';
+        }
+
+        $directory = str_replace('\\', '/', dirname($path));
         if ($directory === '/' || $directory === '.' || $directory === '') {
             return '';
         }

--- a/tests/run.php
+++ b/tests/run.php
@@ -38,6 +38,7 @@ $assert = new Assert();
 
 testRouter($assert);
 testCsrfMiddleware($assert);
+testRequestBasePathDetection($assert);
 
 echo 'OK (' . $assert->count() . " assertions)\n";
 
@@ -155,6 +156,40 @@ function testCsrfMiddleware(Assert $assert): void
         $thrown = true;
     }
     $assert->true($thrown, 'Invalid token should trigger RuntimeException');
+}
+
+function testRequestBasePathDetection(Assert $assert): void
+{
+    $session = [];
+    $request = new Request([], [], [
+        'REQUEST_METHOD' => 'GET',
+        'REQUEST_URI' => '/app/memo',
+        'SCRIPT_NAME' => '/app/index.php',
+    ], [], [], $session);
+
+    $assert->same('/app', $request->basePath(), 'SCRIPT_NAME should define base path when present');
+    $assert->same('/memo', $request->path(), 'Request path should strip base path correctly');
+
+    $session = [];
+    $requestWithPhpSelf = new Request([], [], [
+        'REQUEST_METHOD' => 'GET',
+        'REQUEST_URI' => '/alias/memo',
+        'SCRIPT_NAME' => '/index.php',
+        'PHP_SELF' => '/alias/index.php',
+    ], [], [], $session);
+
+    $assert->same('/alias', $requestWithPhpSelf->basePath(), 'PHP_SELF should be used when SCRIPT_NAME lacks prefix');
+    $assert->same('/memo', $requestWithPhpSelf->path(), 'Path should use detected base path from PHP_SELF');
+
+    $session = [];
+    $requestWithForwarded = new Request([], [], [
+        'REQUEST_METHOD' => 'GET',
+        'REQUEST_URI' => '/memo',
+        'HTTP_X_FORWARDED_PREFIX' => '/tenant',
+    ], [], [], $session);
+
+    $assert->same('/tenant', $requestWithForwarded->basePath(), 'Forwarded prefix header should set base path');
+    $assert->same('/memo', $requestWithForwarded->path(), 'Forwarded prefix should not affect normalized path');
 }
 
 /**


### PR DESCRIPTION
## Summary
- broaden the HTTP request base-path detection to respect forwarded prefixes, web-server context prefixes, and PHP_SELF fallbacks so `/memo` works from subdirectories
- add regression tests ensuring the request helper strips prefixes correctly in these deployment scenarios

## Testing
- php tests/run.php
- php -l core/Request.php
- php -l tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68eeb2a1f7988328a338790ee7d7bec1