### PR TITLE
Add public memo entry point for portal links

### DIFF
--- a/app/Controllers/PortalController.php
+++ b/app/Controllers/PortalController.php
@@ -20,7 +20,7 @@ final class PortalController
             return $prefix . $normalized;
         };
 
-        $memoUrl = $prefix . '/memo';
+        $memoUrl = $prefix . '/memo.php';
         $mindmapUrl = $memoUrl . '?cat=mindmaps';
 
         $todoItems = $this->loadTodoItems($pdo, $memoUrl);

--- a/public/memo.php
+++ b/public/memo.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Controllers\MemoController;
+use App\Memo\Legacy\LegacyMemoRunner;
+use App\Middlewares\CsrfMiddleware;
+use App\Support\SessionConfigurator;
+use Core\Request;
+
+$config = require __DIR__ . '/../bootstrap.php';
+
+SessionConfigurator::configure($config);
+
+if (session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+
+$baseUrl = (string)($config->get('app.base_url', '') ?? '');
+$basePath = '';
+if ($baseUrl !== '') {
+    $parsedPath = parse_url($baseUrl, PHP_URL_PATH);
+    if (is_string($parsedPath)) {
+        $basePath = $parsedPath;
+    }
+}
+
+$request = Request::fromGlobals($basePath);
+$csrf = new CsrfMiddleware();
+$runner = new LegacyMemoRunner($config);
+$controller = new MemoController($runner, $csrf);
+
+if ($request->isPost()) {
+    $controller->store($request);
+} else {
+    $controller->index($request);
+}

--- a/public/memo/index.php
+++ b/public/memo/index.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../memo.php';


### PR DESCRIPTION
## Summary
- add a front controller at public/memo.php that boots the legacy memo runner so portal links resolve without hitting missing files
- provide public/memo/index.php shim to support directory-style access for memo URLs

## Testing
- php -l public/memo.php
- php -l public/memo/index.php
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68eebc2a05548328bf0319c35e212198