### PR TITLE
Allow CDN resources for fonts and Leaflet

### DIFF
--- a/MAX--/index.html
+++ b/MAX--/index.html
@@ -13,7 +13,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css"
-      integrity="Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
+      integrity="sha512-Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -632,7 +632,7 @@
     </section>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"
-      integrity="BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
+      integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
       defer

--- a/config/security.php
+++ b/config/security.php
@@ -22,11 +22,12 @@ return [
     'csp' => [
         'mode' => 'enforce',
         'directives' => [
-            'default-src' => "'self' cdn.jsdelivr.net",
+            'default-src' => "'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
             'img-src' => "'self' data: blob:",
-            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
-            'font-src' => "'self' data:",
-            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
+            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com",
+            'font-src' => "'self' data: https://fonts.gstatic.com",
+            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+            'connect-src' => "'self' https://fonts.gstatic.com",
             'base-uri' => "'self'",
             'form-action' => "'self'",
             'frame-ancestors' => "'self'",

--- a/memo.php
+++ b/memo.php
@@ -176,7 +176,7 @@ function memo_apply_default_security_headers(): void {
   header('X-Frame-Options: SAMEORIGIN');
   header('Referrer-Policy: strict-origin-when-cross-origin');
   header('X-Content-Type-Options: nosniff');
-  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' data:; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
+  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com; connect-src 'self' https://fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
   MemoEnvironment::markSecurityHeadersApplied();
 }
 

--- a/resources/views/portal/index.phtml
+++ b/resources/views/portal/index.phtml
@@ -23,7 +23,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css"
-      integrity="Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
+      integrity="sha512-Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -656,7 +656,7 @@
     </section>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"
-      integrity="BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
+      integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
       defer


### PR DESCRIPTION
## Summary
- relax the CSP directives to allow Google Fonts and cdnjs resources used by the portal
- keep the legacy memo entry point in sync with the updated CSP directives
- fix Leaflet CDN integrity attributes by specifying the correct sha512 algorithm prefix

## Testing
- php -l config/security.php memo.php resources/views/portal/index.phtml
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68eec61ebb548328ac4cfc5deefbc295