### PR TITLE
Adjust CSP for external CDNs

### DIFF
--- a/MAX--/index.html
+++ b/MAX--/index.html
@@ -13,7 +13,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css"
-      integrity="Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
+      integrity="sha512-Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -632,7 +632,7 @@
     </section>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"
-      integrity="BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
+      integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
       defer

--- a/config/security.php
+++ b/config/security.php
@@ -22,11 +22,11 @@ return [
     'csp' => [
         'mode' => 'enforce',
         'directives' => [
-            'default-src' => "'self' cdn.jsdelivr.net",
+            'default-src' => "'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com https://fonts.gstatic.com",
             'img-src' => "'self' data: blob:",
-            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
-            'font-src' => "'self' data:",
-            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net",
+            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com",
+            'font-src' => "'self' data: https://fonts.gstatic.com",
+            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
             'base-uri' => "'self'",
             'form-action' => "'self'",
             'frame-ancestors' => "'self'",

--- a/resources/views/portal/index.phtml
+++ b/resources/views/portal/index.phtml
@@ -23,7 +23,7 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.css"
-      integrity="Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
+      integrity="sha512-Zcn6bjR/8RZbLEpLIeOwNtzREBAJnUKESxces60Mpoj+2okopSAcSUIUOseddDm0cxnGQzxIR7vJgsLZbdLE3w=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -656,7 +656,7 @@
     </section>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"
-      integrity="BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
+      integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
       defer


### PR DESCRIPTION
## Summary
- expand the CSP directives to allow required Google Fonts and cdnjs assets
- fix Leaflet CDN includes to use valid sha512 integrity attributes in both templates

## Testing
- php -l config/security.php
- php -l resources/views/portal/index.phtml
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68eec61ebb548328ac4cfc5deefbc295