### PR TITLE
Fix portal map tiles by switching to OpenStreetMap

### DIFF
--- a/MAX--/script.js
+++ b/MAX--/script.js
@@ -882,37 +882,12 @@
       maxZoom: 8,
     }).setView([20, 0], 2);
 
-    L.tileLayer(
-      "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
-      {
-        maxZoom: 19,
-        minZoom: 2,
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ' +
-          '&copy; <a href="https://carto.com/attributions">CARTO</a>',
-      },
-    ).addTo(map);
-
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-lines/{z}/{x}/{y}.png",
-      {
-        maxZoom: 18,
-        opacity: 0.25,
-        attribution:
-          'Linework by <a href="http://stamen.com">Stamen Design</a> under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>',
-      },
-    ).addTo(map);
-
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}.png",
-      {
-        maxZoom: 20,
-        attribution:
-          'Labels by <a href="http://stamen.com">Stamen Design</a> ' +
-          'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>.' +
-          ' Data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
-      },
-    ).addTo(map);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 19,
+      minZoom: 2,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    }).addTo(map);
 
     const focusMarkerIcon = L.divIcon({
       className: "active-location-marker",

--- a/MAX--/style.css
+++ b/MAX--/style.css
@@ -2646,6 +2646,10 @@ body::after {
   filter: saturate(0.75);
 }
 
+.map-viewport .leaflet-tile {
+  filter: brightness(0.58) contrast(1.28) saturate(0.82);
+}
+
 .map-overlay {
   position: absolute;
   inset: 0;

--- a/public/assets/portal/script.js
+++ b/public/assets/portal/script.js
@@ -882,37 +882,12 @@
       maxZoom: 8,
     }).setView([20, 0], 2);
 
-    L.tileLayer(
-      "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
-      {
-        maxZoom: 19,
-        minZoom: 2,
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ' +
-          '&copy; <a href="https://carto.com/attributions">CARTO</a>',
-      },
-    ).addTo(map);
-
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-lines/{z}/{x}/{y}.png",
-      {
-        maxZoom: 18,
-        opacity: 0.25,
-        attribution:
-          'Linework by <a href="http://stamen.com">Stamen Design</a> under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>',
-      },
-    ).addTo(map);
-
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}.png",
-      {
-        maxZoom: 20,
-        attribution:
-          'Labels by <a href="http://stamen.com">Stamen Design</a> ' +
-          'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>.' +
-          ' Data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
-      },
-    ).addTo(map);
+    L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 19,
+      minZoom: 2,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    }).addTo(map);
 
     const focusMarkerIcon = L.divIcon({
       className: "active-location-marker",

--- a/public/assets/portal/style.css
+++ b/public/assets/portal/style.css
@@ -2793,6 +2793,10 @@ body::after {
   filter: saturate(0.75);
 }
 
+.map-viewport .leaflet-tile {
+  filter: brightness(0.58) contrast(1.28) saturate(0.82);
+}
+
 .map-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- replace defunct Carto and Stamen tile layers with the publicly available OpenStreetMap raster layer
- tweak Leaflet tile styling so the new map retains the dark themed presentation
- mirror the map changes in the static MAX-- build

## Testing
- php tests/run.php
- npx eslint --config /tmp/eslint.config.mjs public/assets/portal/script.js MAX--/script.js

------
https://chatgpt.com/codex/tasks/task_e_68eec87ff7b083289488665b6883facb