### PR TITLE
修复门户信号地图底图加载失败的问题

### DIFF
--- a/public/assets/portal/script.js
+++ b/public/assets/portal/script.js
@@ -272,10 +272,7 @@
   const runDecryptionSequence = async () => {
     const timings = getDecryptionTimings();
     const totalDuration =
-      timings.static +
-      timings.terminal +
-      timings.converge +
-      timings.complete;
+      timings.static + timings.terminal + timings.converge + timings.complete;
     if (!decryptionSequence) {
       await wait(totalDuration);
       return;
@@ -882,37 +879,84 @@
       maxZoom: 8,
     }).setView([20, 0], 2);
 
-    L.tileLayer(
-      "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
-      {
-        maxZoom: 19,
-        minZoom: 2,
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ' +
-          '&copy; <a href="https://carto.com/attributions">CARTO</a>',
-      },
-    ).addTo(map);
+    const mapViewportClassList = mapElement.classList;
 
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-lines/{z}/{x}/{y}.png",
-      {
-        maxZoom: 18,
-        opacity: 0.25,
-        attribution:
-          'Linework by <a href="http://stamen.com">Stamen Design</a> under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>',
-      },
-    ).addTo(map);
+    const applyMapTheme = (theme) => {
+      if (!mapViewportClassList) {
+        return;
+      }
+      if (theme === "light") {
+        mapViewportClassList.add("map-viewport--fallback-light");
+      } else {
+        mapViewportClassList.remove("map-viewport--fallback-light");
+      }
+    };
 
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}.png",
+    const baseTileSources = [
       {
-        maxZoom: 20,
-        attribution:
-          'Labels by <a href="http://stamen.com">Stamen Design</a> ' +
-          'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>.' +
-          ' Data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
+        name: "Carto Dark",
+        theme: "dark",
+        url: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
+        options: {
+          maxZoom: 19,
+          minZoom: 2,
+          subdomains: "abcd",
+          attribution:
+            '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ' +
+            '&copy; <a href="https://carto.com/attributions">CARTO</a>',
+        },
       },
-    ).addTo(map);
+      {
+        name: "OpenStreetMap",
+        theme: "light",
+        url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+        options: {
+          maxZoom: 19,
+          minZoom: 2,
+          attribution:
+            'Map data © <a href="https://www.openstreetmap.org">OpenStreetMap</a> contributors',
+        },
+      },
+    ];
+
+    let activeBaseLayer = null;
+    let activeBaseIndex = -1;
+
+    const activateBaseLayer = (index) => {
+      const source = baseTileSources[index];
+      if (!source) {
+        return;
+      }
+
+      if (activeBaseLayer) {
+        activeBaseLayer.remove();
+        activeBaseLayer = null;
+      }
+
+      activeBaseIndex = index;
+      applyMapTheme(source.theme);
+      mapElement.dataset.tileSource = source.name;
+
+      const layer = L.tileLayer(source.url, source.options).addTo(map);
+
+      layer.on("tileerror", () => {
+        const nextIndex = activeBaseIndex + 1;
+        if (nextIndex >= baseTileSources.length) {
+          return;
+        }
+        console.warn(
+          "Map tile source failed, switching to fallback",
+          baseTileSources[activeBaseIndex]?.name,
+          "→",
+          baseTileSources[nextIndex]?.name,
+        );
+        activateBaseLayer(nextIndex);
+      });
+
+      activeBaseLayer = layer;
+    };
+
+    activateBaseLayer(0);
 
     const focusMarkerIcon = L.divIcon({
       className: "active-location-marker",

--- a/public/assets/portal/style.css
+++ b/public/assets/portal/style.css
@@ -2790,7 +2790,12 @@ body::after {
   height: 100%;
   position: absolute;
   inset: 0;
+  background-color: #05070d;
   filter: saturate(0.75);
+}
+
+.map-viewport.map-viewport--fallback-light {
+  filter: grayscale(0.8) brightness(0.65) contrast(1.35) saturate(0.9);
 }
 
 .map-overlay {


### PR DESCRIPTION
## Summary
- 为门户面板地图新增底图源列表与自动回退机制，避免主数据源不可用时出现纯白画面
- 新增底图主题切换和数据源标记，同时为备用明亮底图应用滤镜以保持整体风格
- 补充地图容器背景色确保在无瓦片时仍能保持深色背景

## Testing
- npx --yes prettier@3.2.5 --check "public/assets/portal/script.js"
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68eec87ff7b083289488665b6883facb