### PR TITLE
调整门户地图背景配色

### DIFF
--- a/public/assets/portal/style.css
+++ b/public/assets/portal/style.css
@@ -1161,7 +1161,9 @@ body::after {
   text-transform: uppercase;
   padding: 6px 8px;
   cursor: pointer;
-  transition: color 0.2s ease, background 0.2s ease;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease;
 }
 
 .dossier__language-button.is-active,
@@ -1284,7 +1286,10 @@ body::after {
   text-transform: uppercase;
   letter-spacing: 0.18em;
   font-size: 0.68rem;
-  transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    background 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .dossier__download-link:hover,
@@ -1840,7 +1845,9 @@ body::after {
   color: var(--amber);
   text-decoration: none;
   text-transform: uppercase;
-  transition: color 0.2s ease, border-color 0.2s ease;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease;
   border-bottom: 1px solid transparent;
   padding-bottom: 2px;
 }
@@ -1984,7 +1991,7 @@ body::after {
 }
 
 .map-card-node::before {
-  content: '▹';
+  content: "▹";
   position: absolute;
   left: 0;
   top: 0;
@@ -2199,7 +2206,7 @@ body::after {
     rgba(255, 59, 59, 0.08) 0%,
     rgba(0, 0, 0, 0.92) 65%,
     rgba(0, 0, 0, 1) 100%
-    );
+  );
 }
 
 .map-card-body:hover .map-preview,
@@ -2790,12 +2797,18 @@ body::after {
   height: 100%;
   position: absolute;
   inset: 0;
-  background-color: #05070d;
-  filter: saturate(0.75);
+  background: radial-gradient(
+      circle at 40% 30%,
+      #2f4c73 0%,
+      #1b2f4b 45%,
+      #0a1628 100%
+    )
+    #101d2f;
+  filter: saturate(0.9);
 }
 
 .map-viewport.map-viewport--fallback-light {
-  filter: grayscale(0.8) brightness(0.65) contrast(1.35) saturate(0.9);
+  filter: grayscale(0.75) brightness(0.85) contrast(1.25) saturate(0.95);
 }
 
 .map-overlay {
@@ -2804,7 +2817,7 @@ body::after {
   background: radial-gradient(
     circle at 50% 50%,
     transparent 0%,
-    rgba(0, 0, 0, 0.7) 95%
+    rgba(0, 0, 0, 0.55) 95%
   );
   pointer-events: none;
   z-index: 3;


### PR DESCRIPTION
## Summary
- 调整门户地图背景为层次更分明的渐变色，并提高饱和度以改善可见度
- 降低遮罩不透明度并优化地图加载失败时的滤镜参数，使 fallback 地图也更明亮

## Testing
- php tests/run.php
- npx --yes prettier --check public/assets/portal/style.css

------
https://chatgpt.com/codex/tasks/task_e_68eecc7e79608328aa316f673b891506