### PR TITLE
Fix CSP to allow CDN map assets

### DIFF
--- a/config/security.php
+++ b/config/security.php
@@ -23,11 +23,11 @@ return [
         'mode' => 'enforce',
         'directives' => [
             'default-src' => "'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
-            'img-src' => "'self' data: blob:",
+            'img-src' => "'self' data: blob: https://tile.openstreetmap.org https://*.basemaps.cartocdn.com",
             'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com",
             'font-src' => "'self' data: https://fonts.gstatic.com",
             'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
-            'connect-src' => "'self' https://fonts.gstatic.com",
+            'connect-src' => "'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://tile.openstreetmap.org https://*.basemaps.cartocdn.com",
             'base-uri' => "'self'",
             'form-action' => "'self'",
             'frame-ancestors' => "'self'",

--- a/memo.php
+++ b/memo.php
@@ -176,7 +176,7 @@ function memo_apply_default_security_headers(): void {
   header('X-Frame-Options: SAMEORIGIN');
   header('Referrer-Policy: strict-origin-when-cross-origin');
   header('X-Content-Type-Options: nosniff');
-  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com; connect-src 'self' https://fonts.gstatic.com; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
+  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://tile.openstreetmap.org https://*.basemaps.cartocdn.com; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com; connect-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://tile.openstreetmap.org https://*.basemaps.cartocdn.com; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
   MemoEnvironment::markSecurityHeadersApplied();
 }
 


### PR DESCRIPTION
## Summary
- allow map tile CDNs in the CSP image sources so Leaflet tiles load
- permit required external hosts for connect-src to unblock CDN sourcemap access

## Testing
- `find app config core public routes tests -name '*.php' -print0 | xargs -0 -n1 php -l`
- `php tests/run.php`


------
https://chatgpt.com/codex/tasks/task_e_68eeced0ad4883289c39fed23bba22ed