### PR TITLE
Allow remote map CDNs in CSP defaults

### DIFF
--- a/app/Support/MemoCspDefaults.php
+++ b/app/Support/MemoCspDefaults.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class MemoCspDefaults
+{
+    /**
+     * @return array<string, string>
+     */
+    public static function directives(): array
+    {
+        return [
+            'default-src' => "'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+            'img-src' => "'self' data: blob: https://tile.openstreetmap.org https://*.basemaps.cartocdn.com https://stamen-tiles.a.ssl.fastly.net https://stamen-tiles-b.a.ssl.fastly.net https://stamen-tiles-c.a.ssl.fastly.net https://stamen-tiles-d.a.ssl.fastly.net",
+            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com",
+            'font-src' => "'self' data: https://fonts.gstatic.com",
+            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
+            'connect-src' => "'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://tile.openstreetmap.org https://*.basemaps.cartocdn.com https://stamen-tiles.a.ssl.fastly.net https://stamen-tiles-b.a.ssl.fastly.net https://stamen-tiles-c.a.ssl.fastly.net https://stamen-tiles-d.a.ssl.fastly.net",
+            'base-uri' => "'self'",
+            'form-action' => "'self'",
+            'frame-ancestors' => "'self'",
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function headerDirectives(): array
+    {
+        $result = [];
+        foreach (self::directives() as $directive => $value) {
+            $directive = trim($directive);
+            $value = trim($value);
+            if ($directive === '' || $value === '') {
+                continue;
+            }
+            $result[] = $directive . ' ' . $value;
+        }
+
+        return $result;
+    }
+}

--- a/config/security.php
+++ b/config/security.php
@@ -1,4 +1,7 @@
 <?php
+
+use App\Support\MemoCspDefaults;
+
 return [
     'session' => [
         'cookie_secure' => (($value = getenv('SESSION_COOKIE_SECURE')) !== false) ? $value : 'auto',
@@ -21,16 +24,6 @@ return [
     ],
     'csp' => [
         'mode' => 'enforce',
-        'directives' => [
-            'default-src' => "'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
-            'img-src' => "'self' data: blob: https://tile.openstreetmap.org https://*.basemaps.cartocdn.com",
-            'style-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com",
-            'font-src' => "'self' data: https://fonts.gstatic.com",
-            'script-src' => "'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com",
-            'connect-src' => "'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://tile.openstreetmap.org https://*.basemaps.cartocdn.com",
-            'base-uri' => "'self'",
-            'form-action' => "'self'",
-            'frame-ancestors' => "'self'",
-        ],
+        'directives' => MemoCspDefaults::directives(),
     ],
 ];

--- a/memo.php
+++ b/memo.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 use App\Memo\Config\AllowedMimes;
 use App\Memo\Legacy\Environment as MemoEnvironment;
+use App\Support\MemoCspDefaults;
 use App\Support\SessionConfigurator;
 
 function memo_start_session(): void {
@@ -176,7 +177,8 @@ function memo_apply_default_security_headers(): void {
   header('X-Frame-Options: SAMEORIGIN');
   header('Referrer-Policy: strict-origin-when-cross-origin');
   header('X-Content-Type-Options: nosniff');
-  header("Content-Security-Policy: default-src 'self' cdn.jsdelivr.net https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://tile.openstreetmap.org https://*.basemaps.cartocdn.com; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' data: https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' cdn.jsdelivr.net https://cdnjs.cloudflare.com; connect-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com https://tile.openstreetmap.org https://*.basemaps.cartocdn.com; base-uri 'self'; form-action 'self'; frame-ancestors 'self'");
+  $cspDirectives = MemoCspDefaults::headerDirectives();
+  header('Content-Security-Policy: ' . implode('; ', $cspDirectives));
   MemoEnvironment::markSecurityHeadersApplied();
 }
 

--- a/tests/run.php
+++ b/tests/run.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Middlewares\CsrfMiddleware;
+use App\Support\MemoCspDefaults;
+use Core\Config;
 use Core\Request;
 use Core\Router;
 
@@ -38,6 +40,7 @@ $assert = new Assert();
 
 testRouter($assert);
 testCsrfMiddleware($assert);
+testSecurityHeaders($assert);
 
 echo 'OK (' . $assert->count() . " assertions)\n";
 
@@ -155,6 +158,52 @@ function testCsrfMiddleware(Assert $assert): void
         $thrown = true;
     }
     $assert->true($thrown, 'Invalid token should trigger RuntimeException');
+}
+
+function testSecurityHeaders(Assert $assert): void
+{
+    $config = new Config(__DIR__ . '/../config');
+    $directives = $config->get('security.csp.directives');
+    $assert->true(is_array($directives), 'CSP directives should be configured as an array');
+
+    $defaults = MemoCspDefaults::directives();
+    $assert->same($defaults, $directives, 'Security configuration should reuse memo CSP defaults');
+
+    $imgSrc = $defaults['img-src'] ?? '';
+    $connectSrc = $defaults['connect-src'] ?? '';
+    $assert->true(str_contains($imgSrc, 'data: blob:'), 'img-src should include the data: blob: scheme with spacing');
+
+    $expectedImageSources = [
+        'https://tile.openstreetmap.org',
+        'https://*.basemaps.cartocdn.com',
+        'https://stamen-tiles.a.ssl.fastly.net',
+        'https://stamen-tiles-b.a.ssl.fastly.net',
+        'https://stamen-tiles-c.a.ssl.fastly.net',
+        'https://stamen-tiles-d.a.ssl.fastly.net',
+    ];
+
+    foreach ($expectedImageSources as $source) {
+        $assert->true(str_contains($imgSrc, $source), 'img-src should allow ' . $source);
+    }
+
+    $expectedConnectSources = [
+        'https://fonts.gstatic.com',
+        'https://cdnjs.cloudflare.com',
+        'https://tile.openstreetmap.org',
+        'https://*.basemaps.cartocdn.com',
+        'https://stamen-tiles.a.ssl.fastly.net',
+        'https://stamen-tiles-b.a.ssl.fastly.net',
+        'https://stamen-tiles-c.a.ssl.fastly.net',
+        'https://stamen-tiles-d.a.ssl.fastly.net',
+    ];
+
+    foreach ($expectedConnectSources as $source) {
+        $assert->true(str_contains($connectSrc, $source), 'connect-src should allow ' . $source);
+    }
+
+    $headerDirectives = MemoCspDefaults::headerDirectives();
+    $headerString = implode('; ', $headerDirectives);
+    $assert->true(str_contains($headerString, "img-src 'self' data: blob:"), 'Header directives should include img-src with data: blob: spacing');
 }
 
 /**


### PR DESCRIPTION
## Summary
- centralize memo CSP directives in a shared helper and extend them to cover external tile providers
- reuse the shared defaults from both the security config and the legacy memo header fallback
- add regression tests to ensure the CSP includes the required CDN hosts and spacing for blob sources

## Testing
- php tests/run.php

------
https://chatgpt.com/codex/tasks/task_e_68ef5effdbb88328aa7d921f4ae4cef4