### PR TITLE
Refine portal dashboard layout

### DIFF
--- a/app/Controllers/PortalController.php
+++ b/app/Controllers/PortalController.php
@@ -2,22 +2,15 @@
 
 namespace App\Controllers;
 
-use App\Middlewares\CsrfMiddleware;
 use Core\DB;
 use Core\Request;
 use PDO;
-use RuntimeException;
-use Throwable;
 
 use function bytes_h;
 use function format_datetime;
 
 final class PortalController
 {
-    public function __construct(private CsrfMiddleware $csrf)
-    {
-    }
-
     public function index(Request $request): void
     {
         $pdo = DB::pdo();
@@ -36,52 +29,7 @@ final class PortalController
         $todoItems = $this->loadTodoItems($pdo, $memoUrl);
         $mindmaps = $this->loadMindmaps($pdo, $memoUrl);
         $recentFiles = $this->loadRecentAssets($pdo, $memoUrl);
-        $directives = $this->loadDirectives($pdo);
-        $csrfToken = $this->csrf->token($request);
-        $directivesPostUrl = $prefix . '/directives';
-
         require __DIR__ . '/../../resources/views/portal/index.phtml';
-    }
-
-    public function storeDirective(Request $request): void
-    {
-        $pdo = DB::pdo();
-
-        try {
-            $this->csrf->verify($request);
-        } catch (RuntimeException $e) {
-            $this->respondJson(['ok' => 0, 'message' => '会话已过期，请刷新后重试'], 419);
-        }
-
-        $nickname = trim((string)$request->input('nickname', ''));
-        $messageInput = $request->input('message', $request->input('note', ''));
-        $message = trim((string)$messageInput);
-
-        if ($nickname === '' || $message === '') {
-            $this->respondJson(['ok' => 0, 'message' => '昵称和留言均不能为空'], 422);
-        }
-
-        $nickname = mb_substr($nickname, 0, 40);
-        $message = mb_substr($message, 0, 240);
-
-        $createdAt = time();
-
-        try {
-            $stmt = $pdo->prepare('INSERT INTO portal_directives(nickname, message, created_at) VALUES(?,?,?)');
-            $stmt->execute([$nickname, $message, $createdAt]);
-        } catch (Throwable) {
-            $this->respondJson(['ok' => 0, 'message' => '保存留言失败，请稍后再试'], 500);
-        }
-
-        $id = (int)$pdo->lastInsertId();
-        $payload = $this->formatDirectiveRow([
-            'id' => $id,
-            'nickname' => $nickname,
-            'message' => $message,
-            'created_at' => $createdAt,
-        ]);
-
-        $this->respondJson(['ok' => 1, 'directive' => $payload], 201);
     }
 
     /**
@@ -93,7 +41,7 @@ final class PortalController
             'SELECT items.id, items.title, items.done, items.updated_at
             FROM items
             ORDER BY items.updated_at DESC, items.id DESC
-            LIMIT 4'
+            LIMIT 5'
         );
         $stmt->execute();
         $items = $stmt->fetchAll();
@@ -128,7 +76,7 @@ final class PortalController
     private function loadMindmaps(PDO $pdo, string $memoUrl): array
     {
         $stmt = $pdo->query(
-            'SELECT id, title, content, updated_at FROM mindmaps ORDER BY updated_at DESC, id DESC LIMIT 4'
+            'SELECT id, title, content, updated_at FROM mindmaps ORDER BY updated_at DESC, id DESC LIMIT 5'
         );
         $rows = $stmt ? $stmt->fetchAll() : [];
         if (!$rows) {
@@ -186,7 +134,7 @@ final class PortalController
              LEFT JOIN mindmaps AS m ON m.id = a.mindmap_id
              WHERE a.context IN ("memo:item", "memo:step", "mindmap:node")
              ORDER BY a.created_at DESC, a.id DESC
-             LIMIT 6'
+             LIMIT 5'
         );
         $stmt->execute();
         $rows = $stmt->fetchAll() ?: [];
@@ -269,74 +217,6 @@ final class PortalController
         }
 
         return $result;
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    private function loadDirectives(PDO $pdo): array
-    {
-        $stmt = $pdo->query(
-            'SELECT id, nickname, message, created_at FROM portal_directives ORDER BY created_at DESC, id DESC LIMIT 12'
-        );
-        $rows = $stmt ? $stmt->fetchAll() : [];
-        if (!$rows) {
-            return [];
-        }
-
-        $result = [];
-        foreach ($rows as $row) {
-            $result[] = $this->formatDirectiveRow($row);
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     * @return array<string, mixed>
-     */
-    private function formatDirectiveRow(array $row): array
-    {
-        $id = (int)($row['id'] ?? 0);
-        $nickname = trim((string)($row['nickname'] ?? ''));
-        if ($nickname === '') {
-            $nickname = '匿名特工';
-        }
-        $message = trim((string)($row['message'] ?? ''));
-        $createdAt = isset($row['created_at']) ? (int)$row['created_at'] : time();
-        if ($createdAt <= 0) {
-            $createdAt = time();
-        }
-
-        return [
-            'id' => $id,
-            'nickname' => $nickname,
-            'message' => $message,
-            'created_at' => $createdAt,
-            'created_label' => date('H:i:s', $createdAt),
-            'created_iso' => date('c', $createdAt),
-            'priority' => $this->determineDirectivePriority($id),
-        ];
-    }
-
-    private function determineDirectivePriority(int $id): string
-    {
-        $cycle = ['high', 'medium', 'low'];
-        $count = count($cycle);
-        if ($count === 0) {
-            return 'medium';
-        }
-        $index = $id % $count;
-        return $cycle[$index];
-    }
-
-    private function respondJson(array $payload, int $status = 200): void
-    {
-        http_response_code($status);
-        header('Content-Type: application/json; charset=utf-8');
-        echo json_encode($payload, JSON_UNESCAPED_UNICODE);
-        exit;
     }
 
     /**

--- a/public/assets/portal/script.js
+++ b/public/assets/portal/script.js
@@ -12,24 +12,6 @@
     return { lat, lon };
   })();
 
-  const directiveForm = document.querySelector(".note-form");
-  const directiveMessageInput = directiveForm
-    ? directiveForm.querySelector("input[name='message']")
-    : null;
-  const directiveNicknameInput = directiveForm
-    ? directiveForm.querySelector("input[name='nickname']")
-    : null;
-  const directiveTokenInput = directiveForm
-    ? directiveForm.querySelector("input[name='_csrf']")
-    : null;
-  const directiveFeedback = directiveForm
-    ? directiveForm.querySelector("[data-feedback]")
-    : null;
-  const directiveEndpoint = directiveForm
-    ? directiveForm.dataset.endpoint || directiveForm.getAttribute("action") || ""
-    : "";
-  const directiveLog = document.querySelector(".directive-log");
-
   const channelList = document.querySelector(".channel-list");
   const channelEntries = channelList
     ? Array.from(channelList.querySelectorAll(".channel-entry"))
@@ -729,162 +711,6 @@
     coordinateElements.lon.textContent = formatCoordinate(lon, "lon");
   };
 
-  const directiveTimeFormatter = new Intl.DateTimeFormat("en-GB", {
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hourCycle: "h23",
-  });
-
-  const setDirectiveFeedback = (message, state = "info") => {
-    if (!directiveFeedback) return;
-    directiveFeedback.textContent = message || "";
-    directiveFeedback.dataset.state = state;
-  };
-
-  const appendDirectiveLog = (entry = {}, highlight = true) => {
-    if (!directiveLog) return null;
-    const priority =
-      typeof entry.priority === "string" && entry.priority
-        ? entry.priority
-        : "medium";
-    const listItem = document.createElement("li");
-    listItem.className = "directive-entry";
-    listItem.dataset.priority = priority;
-    if (highlight) {
-      listItem.classList.add("is-new");
-    }
-
-    const content = document.createElement("span");
-    content.className = "directive-content";
-
-    const priorityDot = document.createElement("span");
-    priorityDot.className = `directive-priority ${priority}`;
-    priorityDot.setAttribute("aria-hidden", "true");
-
-    const text = document.createElement("span");
-    text.className = "directive-text";
-
-    const directiveMessage = document.createElement("span");
-    directiveMessage.className = "directive-message";
-    directiveMessage.textContent = entry.message || "";
-
-    const meta = document.createElement("span");
-    meta.className = "directive-meta";
-
-    const author = document.createElement("span");
-    author.className = "directive-author";
-    author.setAttribute("aria-label", "Author");
-    author.textContent = entry.nickname || "";
-
-    const divider = document.createElement("span");
-    divider.className = "directive-divider";
-    divider.setAttribute("aria-hidden", "true");
-    divider.textContent = "—";
-
-    const time = document.createElement("time");
-    time.className = "directive-time";
-    const timestamp =
-      typeof entry.created_at === "number" && entry.created_at > 0
-        ? entry.created_at * 1000
-        : Date.now();
-    const formattedLabel =
-      entry.created_label || directiveTimeFormatter.format(new Date(timestamp));
-    time.textContent = formattedLabel;
-    if (entry.created_iso) {
-      time.dateTime = entry.created_iso;
-    } else {
-      time.dateTime = new Date(timestamp).toISOString();
-    }
-
-    meta.append(author, divider, time);
-    text.append(directiveMessage, meta);
-
-    const hiddenPriority = document.createElement("span");
-    hiddenPriority.className = "visually-hidden";
-    hiddenPriority.textContent = `Priority ${priority.toUpperCase()}`;
-
-    content.append(priorityDot, text, hiddenPriority);
-    listItem.append(content);
-    directiveLog.prepend(listItem);
-
-    if (highlight) {
-      window.setTimeout(() => {
-        listItem.classList.remove("is-new");
-      }, 700);
-    }
-
-    return listItem;
-  };
-
-  if (
-    directiveForm &&
-    directiveMessageInput &&
-    directiveNicknameInput &&
-    directiveTokenInput &&
-    directiveLog
-  ) {
-    directiveForm.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      const nickname = directiveNicknameInput.value.trim();
-      const message = directiveMessageInput.value.trim();
-      if (!nickname || !message) {
-        setDirectiveFeedback("请填写昵称和留言内容", "error");
-        return;
-      }
-      if (!directiveEndpoint) {
-        setDirectiveFeedback("提交地址缺失", "error");
-        return;
-      }
-
-      const params = new URLSearchParams();
-      params.set("nickname", nickname);
-      params.set("message", message);
-      params.set("_csrf", directiveTokenInput.value || "");
-
-      directiveForm.classList.add("is-submitting");
-      directiveMessageInput.disabled = true;
-      directiveNicknameInput.disabled = true;
-      setDirectiveFeedback("正在提交…", "info");
-
-      try {
-        const response = await fetch(directiveEndpoint, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
-            "X-Requested-With": "XMLHttpRequest",
-            Accept: "application/json",
-          },
-          body: params.toString(),
-        });
-
-        const contentType = response.headers.get("content-type") || "";
-        const isJson = contentType.includes("application/json");
-        const payload = isJson ? await response.json() : null;
-
-        if (!response.ok || !payload?.ok) {
-          const feedback = payload?.message || "留言提交失败，请稍后再试";
-          setDirectiveFeedback(feedback, "error");
-          return;
-        }
-
-        appendDirectiveLog(payload.directive || {}, true);
-        setDirectiveFeedback("留言已记录", "success");
-        directiveMessageInput.value = "";
-        window.requestAnimationFrame(() => {
-          directiveMessageInput.classList.add("is-commit");
-        });
-      } catch (error) {
-        setDirectiveFeedback("网络异常，请稍后再试", "error");
-      } finally {
-        directiveForm.classList.remove("is-submitting");
-        directiveMessageInput.disabled = false;
-        directiveNicknameInput.disabled = false;
-        directiveMessageInput.focus();
-      }
-    });
-  }
-
   const channelFormatterCache = new Map();
   const getChannelFormatter = (timezone) => {
     if (!timezone) return null;
@@ -931,260 +757,224 @@
     scrambleTrack.style.setProperty("--scramble-duration", `${duration}s`);
   }
 
-  const initializeMap = () => {
-    const mapElement = document.getElementById("map");
-    if (!mapElement || typeof L === "undefined") {
+  const mapOverlay = document.querySelector(".map-overlay");
+  const networkNodes = [
+    {
+      id: "albania",
+      label: "ALBANIA",
+      coords: [41.1533, 20.1683],
+    },
+    {
+      id: "switzerland",
+      label: "SWITZERLAND",
+      coords: [46.8182, 8.2275],
+    },
+    {
+      id: "beijing",
+      label: "BEIJING",
+      coords: [39.9042, 116.4074],
+    },
+    {
+      id: "shanghai",
+      label: "SHANGHAI",
+      coords: [31.2304, 121.4737],
+    },
+    {
+      id: "dubai",
+      label: "DUBAI",
+      coords: [25.2048, 55.2708],
+    },
+    {
+      id: "huludao",
+      label: "HULUDAO",
+      coords: [40.709, 120.8377],
+    },
+    {
+      id: "philippines",
+      label: "PHILIPPINES",
+      coords: [12.8797, 121.774],
+    },
+    {
+      id: "zhengzhou",
+      label: "ZHENGZHOU",
+      coords: [34.7466, 113.6254],
+    },
+    {
+      id: "pingdingshan",
+      label: "PINGDINGSHAN",
+      coords: [33.7665, 113.1927],
+    },
+  ];
+
+  const projectCoordinates = (coords) => {
+    if (!Array.isArray(coords) || coords.length < 2) {
+      return null;
+    }
+    const [lat, lon] = coords;
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+      return null;
+    }
+    const x = ((lon + 180) / 360) * 100;
+    const y = ((90 - lat) / 180) * 100;
+    return {
+      x: clamp(x, 0, 100),
+      y: clamp(y, 0, 100),
+    };
+  };
+
+  const markers = new Map();
+  let activeNodeIndex = -1;
+  let rotationTimerId = null;
+  let targetingTimerId = null;
+  const rotationInterval = 7000;
+
+  const setOverlayLabel = (label) => {
+    if (!mapOverlay) return;
+    mapOverlay.setAttribute("data-active-label", label || "");
+  };
+
+  const triggerTargetingPulse = () => {
+    if (!mapScreen) return;
+    mapScreen.classList.add("is-targeting");
+    if (targetingTimerId) {
+      window.clearTimeout(targetingTimerId);
+    }
+    targetingTimerId = window.setTimeout(() => {
+      mapScreen.classList.remove("is-targeting");
+    }, 900);
+  };
+
+  const resetRotation = () => {
+    if (rotationTimerId) {
+      window.clearInterval(rotationTimerId);
+      rotationTimerId = null;
+    }
+  };
+
+  const startRotation = () => {
+    if (!networkNodes.length) {
+      return;
+    }
+    resetRotation();
+    rotationTimerId = window.setInterval(() => {
+      const nextIndex = (activeNodeIndex + 1) % networkNodes.length;
+      setActiveNode(nextIndex);
+    }, rotationInterval);
+  };
+
+  const setActiveNode = (index, { manual = false } = {}) => {
+    if (!networkNodes.length) {
+      resetCoordinateDisplay();
+      setOverlayLabel("");
       return;
     }
 
-    const worldBounds = [
-      [-90, -180],
-      [90, 180],
-    ];
+    const boundedIndex = ((index % networkNodes.length) + networkNodes.length) % networkNodes.length;
+    if (boundedIndex === activeNodeIndex && !manual) {
+      return;
+    }
 
-    const map = L.map(mapElement, {
-      worldCopyJump: false,
-      zoomControl: false,
-      attributionControl: false,
-      maxBoundsViscosity: 0.8,
-      maxBounds: worldBounds,
-      minZoom: 2,
-      maxZoom: 8,
-    }).setView([20, 0], 2);
-
-    L.tileLayer(
-      "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png",
-      {
-        maxZoom: 19,
-        minZoom: 2,
-        attribution:
-          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ' +
-          '&copy; <a href="https://carto.com/attributions">CARTO</a>',
-      },
-    ).addTo(map);
-
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-lines/{z}/{x}/{y}.png",
-      {
-        maxZoom: 18,
-        opacity: 0.25,
-        attribution:
-          'Linework by <a href="http://stamen.com">Stamen Design</a> under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>',
-      },
-    ).addTo(map);
-
-    L.tileLayer(
-      "https://stamen-tiles.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}.png",
-      {
-        maxZoom: 20,
-        attribution:
-          'Labels by <a href="http://stamen.com">Stamen Design</a> ' +
-          'under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>.' +
-          ' Data © <a href="http://openstreetmap.org">OpenStreetMap</a>',
-      },
-    ).addTo(map);
-
-    const focusMarkerIcon = L.divIcon({
-      className: "active-location-marker",
-      html: `
-        <span class="marker-star" aria-hidden="true">★</span>
-      `,
-      iconSize: [44, 44],
-      iconAnchor: [22, 22],
-      tooltipAnchor: [0, -24],
-    });
-
-    const focusMarker = L.marker([0, 0], {
-      icon: focusMarkerIcon,
-      interactive: false,
-    });
-
-    const normaliseCoords = (coords) => {
-      if (!coords) return null;
-      if (Array.isArray(coords) && coords.length >= 2) {
-        const [lat, lon] = coords;
-        if (Number.isFinite(lat) && Number.isFinite(lon)) {
-          return [lat, lon];
-        }
-        return null;
+    const previousNode = activeNodeIndex >= 0 ? networkNodes[activeNodeIndex] : null;
+    if (previousNode) {
+      const previousMarker = markers.get(resolveNodeKey(previousNode, activeNodeIndex));
+      if (previousMarker) {
+        previousMarker.classList.remove("is-active");
+        previousMarker.setAttribute("aria-pressed", "false");
       }
-      if (typeof coords.lat === "number" && typeof coords.lng === "number") {
-        return [coords.lat, coords.lng];
-      }
-      if (typeof coords.lat === "number" && typeof coords.lon === "number") {
-        return [coords.lat, coords.lon];
-      }
+    }
+
+    activeNodeIndex = boundedIndex;
+    const node = networkNodes[boundedIndex];
+    const marker = markers.get(resolveNodeKey(node, boundedIndex));
+    if (marker) {
+      marker.classList.add("is-active");
+      marker.setAttribute("aria-pressed", "true");
+    }
+
+    updateCoordinateDisplay(node.coords);
+    setOverlayLabel(node.label || "");
+    triggerTargetingPulse();
+
+    if (manual) {
+      startRotation();
+    }
+  };
+
+  const resolveNodeKey = (node, index) => {
+    if (node && typeof node.id === "string" && node.id.trim() !== "") {
+      return node.id;
+    }
+    return `node-${index}`;
+  };
+
+  const createMarkerElement = (node, index) => {
+    const position = projectCoordinates(node.coords);
+    if (!position) {
       return null;
+    }
+
+    const marker = document.createElement("button");
+    marker.type = "button";
+    marker.className = "network-marker";
+    marker.style.left = `${position.x}%`;
+    marker.style.top = `${position.y}%`;
+    const nodeKey = resolveNodeKey(node, index);
+    marker.dataset.nodeId = nodeKey;
+    marker.setAttribute("aria-label", `${node.label ?? "Network node"} node`);
+    marker.setAttribute("aria-pressed", "false");
+    marker.title = node.label || "";
+
+    const activate = () => {
+      setActiveNode(index, { manual: true });
     };
 
-    const ensureMarkerVisible = (coords) => {
-      if (!coords) return;
-      if (!map.hasLayer(focusMarker)) {
-        focusMarker.addTo(map);
+    marker.addEventListener("click", activate);
+    marker.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        activate();
       }
-      focusMarker.setLatLng(coords);
-    };
+    });
 
-    const pointToLocation = (coords, { shouldFly = false, zoom } = {}) => {
-      const target = normaliseCoords(coords);
-      if (!target) {
-        resetCoordinateDisplay();
+    return marker;
+  };
+
+  const buildNetworkLayer = (container) => {
+    markers.clear();
+    networkNodes.forEach((node, index) => {
+      const marker = createMarkerElement(node, index);
+      if (!marker) {
         return;
       }
-      ensureMarkerVisible(target);
-      if (shouldFly) {
-        map.flyTo(target, zoom ?? Math.max(map.getZoom(), 4.5), {
-          duration: 0.8,
-        });
-      }
-      updateCoordinateDisplay(target);
-    };
-
-    const networkNodes = [
-      {
-        id: "albania",
-        label: "ALBANIA",
-        coords: [41.1533, 20.1683],
-        pulseDelay: 0,
-      },
-      {
-        id: "switzerland",
-        label: "SWITZERLAND",
-        coords: [46.8182, 8.2275],
-        pulseDelay: 0.6,
-      },
-      {
-        id: "beijing",
-        label: "BEIJING",
-        coords: [39.9042, 116.4074],
-        pulseDelay: 1.2,
-      },
-      {
-        id: "shanghai",
-        label: "SHANGHAI",
-        coords: [31.2304, 121.4737],
-        pulseDelay: 1.8,
-      },
-      {
-        id: "dubai",
-        label: "DUBAI",
-        coords: [25.2048, 55.2708],
-        pulseDelay: 2.4,
-        zoom: 6,
-      },
-      {
-        id: "huludao",
-        label: "HULUDAO",
-        coords: [40.709, 120.8377],
-        pulseDelay: 3,
-      },
-      {
-        id: "philippines",
-        label: "PHILIPPINES",
-        coords: [12.8797, 121.774],
-        pulseDelay: 3.6,
-      },
-      {
-        id: "zhengzhou",
-        label: "ZHENGZHOU",
-        coords: [34.7466, 113.6254],
-        pulseDelay: 4.2,
-      },
-      {
-        id: "pingdingshan",
-        label: "PINGDINGSHAN",
-        coords: [33.7665, 113.1927],
-        pulseDelay: 4.8,
-      },
-    ];
-
-    const nodeIcon = (delay = 0) =>
-      L.divIcon({
-        className: "network-pin",
-        html: `
-          <span class="pin-tail"></span>
-          <span class="pin-core"></span>
-          <span class="pin-pulse" style="animation-delay: ${delay}s"></span>
-        `,
-        iconSize: [28, 28],
-        iconAnchor: [14, 26],
-        tooltipAnchor: [0, -22],
-      });
-
-    networkNodes.forEach((node) => {
-      const marker = L.marker(node.coords, { icon: nodeIcon(node.pulseDelay) })
-        .addTo(map)
-        .bindTooltip(node.label, {
-          direction: "top",
-          offset: [0, -24],
-          className: "network-tooltip",
-        });
-
-      marker.on("click", () => {
-        pointToLocation(node.coords, { shouldFly: true, zoom: node.zoom ?? 5 });
-      });
-    });
-
-    const updateCoordinatesFromMap = () => {
-      const center = map.getCenter();
-      const target = normaliseCoords(center);
-      if (!target) {
-        resetCoordinateDisplay();
-        return;
-      }
-      ensureMarkerVisible(target);
-      updateCoordinateDisplay(target);
-    };
-
-    map.whenReady(() => {
-      updateCoordinatesFromMap();
-    });
-
-    map.on("move", updateCoordinatesFromMap);
-    map.on("moveend", updateCoordinatesFromMap);
-    map.on("zoomend", updateCoordinatesFromMap);
-
-    map.on("click", (event) => {
-      pointToLocation(event.latlng);
-    });
-
-    let moveVisualTimeoutId = null;
-
-    map.on("movestart", () => {
-      if (moveVisualTimeoutId) {
-        window.clearTimeout(moveVisualTimeoutId);
-        moveVisualTimeoutId = null;
-      }
-      if (mapScreen) {
-        mapScreen.classList.add("is-moving");
-      }
-    });
-
-    map.on("moveend", () => {
-      if (moveVisualTimeoutId) {
-        window.clearTimeout(moveVisualTimeoutId);
-      }
-      moveVisualTimeoutId = window.setTimeout(() => {
-        if (mapScreen) {
-          mapScreen.classList.remove("is-moving");
-        }
-      }, 240);
-    });
-
-    map.on("unload", () => {
-      if (moveVisualTimeoutId) {
-        window.clearTimeout(moveVisualTimeoutId);
-        moveVisualTimeoutId = null;
-      }
-      if (mapScreen) {
-        mapScreen.classList.remove("is-moving");
-      }
+      container.append(marker);
+      markers.set(resolveNodeKey(node, index), marker);
     });
   };
 
+  const initializeNetworkDisplay = () => {
+    const mapElement = document.getElementById("map");
+    if (!mapElement) {
+      return;
+    }
+
+    mapElement.textContent = "";
+    setOverlayLabel("");
+    const layer = document.createElement("div");
+    layer.className = "map-network-layer";
+    mapElement.append(layer);
+    buildNetworkLayer(layer);
+
+    if (networkNodes.length) {
+      setActiveNode(0);
+      startRotation();
+    } else {
+      resetCoordinateDisplay();
+    }
+  };
+
   if (document.readyState === "complete") {
-    initializeMap();
+    initializeNetworkDisplay();
   } else {
-    window.addEventListener("load", initializeMap, { once: true });
+    window.addEventListener("load", initializeNetworkDisplay, { once: true });
   }
 })();

--- a/public/assets/portal/style.css
+++ b/public/assets/portal/style.css
@@ -351,310 +351,6 @@ body::after {
   box-shadow: inset 0 0 0 1px rgba(255, 59, 59, 0.18);
 }
 
-.directive-block {
-  isolation: isolate;
-}
-
-.directive-block::after {
-  content: "";
-  position: absolute;
-  inset: 10px 6px 12px 6px;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140' viewBox='0 0 140 140'%3E%3Cfilter id='f'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='1.4' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23f)' opacity='0.25'/%3E%3C/svg%3E");
-  mix-blend-mode: screen;
-  opacity: 0.04;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.directive-log {
-  position: relative;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 18px;
-  padding: 6px 2px 4px 0;
-  gap: 0;
-}
-
-.directive-entry {
-  position: relative;
-  display: block;
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
-  padding: 11px 0 13px 18px;
-  border-top: 1px dashed rgba(255, 255, 255, 0.08);
-  min-width: 0;
-}
-
-.directive-entry:first-of-type {
-  border-top: none;
-  padding-top: 2px;
-}
-
-.directive-entry::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  transform: translateX(-10px) skewX(-0.4deg);
-  background:
-    linear-gradient(180deg, rgba(255, 59, 59, 0.05), rgba(255, 59, 59, 0)),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.04), transparent 70%);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.4s ease;
-  z-index: -1;
-}
-
-.directive-entry:hover::after {
-  opacity: 0.22;
-}
-
-.directive-entry[data-priority="high"] .directive-content {
-  --priority-tone: var(--priority-high);
-}
-
-.directive-entry[data-priority="medium"] .directive-content {
-  --priority-tone: #e4973e;
-}
-
-.directive-entry[data-priority="low"] .directive-content {
-  --priority-tone: #b0b0b0;
-}
-
-.directive-content {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  align-items: start;
-  column-gap: 12px;
-  min-width: 0;
-  color: var(--priority-tone, #b0b0b0);
-  text-transform: uppercase;
-}
-
-.directive-content::before {
-  content: "";
-  position: absolute;
-  top: 7px;
-  left: -18px;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--priority-tone, var(--accent-red));
-  box-shadow: 0 0 12px rgba(255, 59, 59, 0.55);
-  opacity: 0;
-  transform: scale(0.5);
-}
-
-.directive-priority {
-  position: relative;
-  flex: 0 0 auto;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: currentColor;
-  color: var(--priority-tone, var(--priority-low));
-  box-shadow: 0 0 8px currentColor;
-  margin-top: 2px;
-}
-
-.directive-priority::after {
-  content: "";
-  position: absolute;
-  inset: -3px;
-  border-radius: 50%;
-  border: 1px solid currentColor;
-  opacity: 0.7;
-}
-
-.directive-priority.high,
-.directive-priority.medium {
-  animation: priorityPulse 1.9s ease-out infinite;
-}
-
-.directive-priority.low {
-  box-shadow: 0 0 4px rgba(176, 176, 176, 0.2);
-}
-
-.directive-text {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  color: #b0b0b0;
-  letter-spacing: 0.08em;
-  line-height: 1.24;
-  padding: 0 10px 0 6px;
-  text-indent: 1px;
-  max-width: 100%;
-  word-break: break-word;
-  overflow-wrap: anywhere;
-  white-space: normal;
-  min-width: 0;
-}
-
-.directive-message {
-  writing-mode: horizontal-tb;
-  white-space: normal;
-}
-
-.directive-author {
-  font-size: 0.62rem;
-  letter-spacing: 0.32em;
-  color: var(--priority-tone, rgba(255, 108, 79, 0.74));
-  opacity: 0.85;
-  text-transform: uppercase;
-  text-shadow: 0 0 6px rgba(255, 59, 59, 0.32);
-}
-
-.directive-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font-size: 0.62rem;
-  letter-spacing: 0.3em;
-  color: var(--priority-tone, rgba(255, 108, 79, 0.74));
-  text-transform: uppercase;
-  padding-left: 2px;
-}
-
-.directive-divider {
-  font-size: 0.6rem;
-  letter-spacing: 0.28em;
-  color: rgba(255, 255, 255, 0.24);
-}
-
-.directive-time {
-  color: rgba(180, 184, 190, 0.68);
-  letter-spacing: 0.28em;
-  text-shadow: 0 0 2px rgba(255, 255, 255, 0.18);
-  filter: blur(0.1px);
-}
-
-.directive-text::before {
-  content: "";
-  position: absolute;
-  inset: -4px 0 -4px 0;
-  background: linear-gradient(90deg, rgba(0, 0, 0, 0.4), transparent 78%);
-  opacity: 0.15;
-  pointer-events: none;
-}
-
-@supports (mask-image: linear-gradient(90deg, #000, rgba(0, 0, 0, 0))) or
-  (-webkit-mask-image: linear-gradient(90deg, #000, rgba(0, 0, 0, 0))) {
-  .directive-text {
-    mask-image: linear-gradient(
-      90deg,
-      #000 0%,
-      #000 88%,
-      rgba(0, 0, 0, 0) 100%
-    );
-    -webkit-mask-image: linear-gradient(
-      90deg,
-      #000 0%,
-      #000 88%,
-      rgba(0, 0, 0, 0) 100%
-    );
-  }
-}
-
-.note-form {
-  position: relative;
-  margin-top: 14px;
-}
-
-.note-form::after {
-  content: "";
-  position: absolute;
-  inset: 6px;
-  border: 1px dashed rgba(255, 59, 59, 0.18);
-  pointer-events: none;
-  opacity: 0.4;
-}
-
-.note-form input {
-  width: 100%;
-  padding: 12px 18px;
-  border: 1px solid rgba(255, 59, 59, 0.32);
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text-strong);
-  font-family: var(--font-body);
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 59, 59, 0.12),
-    inset 0 0 14px rgba(0, 0, 0, 0.45);
-  transition:
-    border-color 0.25s ease,
-    box-shadow 0.25s ease,
-    background-color 0.25s ease;
-}
-
-.note-form input:focus {
-  outline: none;
-  border-color: rgba(255, 59, 59, 0.65);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 59, 59, 0.24),
-    inset 0 0 22px rgba(255, 59, 59, 0.14);
-  background-color: rgba(47, 9, 9, 0.25);
-}
-
-.note-form input::placeholder {
-  color: rgba(255, 207, 207, 0.38);
-  letter-spacing: 0.16em;
-  text-transform: none;
-}
-
-.note-form input.is-commit {
-  animation: inputFlash 0.14s ease;
-}
-
-.note-form-fields {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.note-form-fields input[name='nickname'] {
-  flex: 0 0 160px;
-  max-width: 220px;
-}
-
-.note-form-fields input[name='message'] {
-  flex: 1 1 240px;
-}
-
-.note-form-feedback {
-  margin-top: 8px;
-  min-height: 0.9rem;
-  font-size: 0.6rem;
-  letter-spacing: 0.18em;
-  color: rgba(255, 207, 207, 0.6);
-  text-transform: uppercase;
-  transition: color 0.2s ease;
-}
-
-.note-form-feedback[data-state='error'] {
-  color: #ff8080;
-}
-
-.note-form-feedback[data-state='success'] {
-  color: #8de8c7;
-}
-
-.note-form-feedback[data-state='info'] {
-  color: rgba(255, 207, 207, 0.7);
-}
-
-.directive-entry.is-new {
-  animation: directiveArrival 0.6s cubic-bezier(0.37, 0.01, 0.29, 1);
-}
-
-.directive-entry.is-new .directive-content::before {
-  animation: directiveDot 0.32s ease-out forwards;
-}
-
 .personnel-card,
 .transmission-card,
 .queue-card,
@@ -2825,7 +2521,34 @@ body::after {
   height: 100%;
   position: absolute;
   inset: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(40, 90, 120, 0.28), rgba(8, 12, 24, 0.92) 72%),
+    linear-gradient(130deg, rgba(8, 15, 24, 0.85), rgba(6, 10, 18, 0.95));
   filter: saturate(0.75);
+}
+
+.map-viewport::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(0deg, rgba(94, 168, 220, 0.14) 0 1px, transparent 1px 32px),
+    repeating-linear-gradient(90deg, rgba(94, 168, 220, 0.14) 0 1px, transparent 1px 32px);
+  opacity: 0.45;
+  mix-blend-mode: screen;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.map-viewport::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(12, 48, 66, 0.32), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: 1;
 }
 
 .map-overlay {
@@ -2838,6 +2561,101 @@ body::after {
   );
   pointer-events: none;
   z-index: 3;
+}
+
+.map-overlay::after {
+  content: attr(data-active-label);
+  position: absolute;
+  top: 18px;
+  left: 24px;
+  font-size: 0.62rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(173, 233, 255, 0.78);
+  text-shadow: 0 0 12px rgba(80, 180, 230, 0.4);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.map-overlay[data-active-label]:not([data-active-label=""])::after {
+  opacity: 1;
+}
+
+.map-network-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+}
+
+.network-marker {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid rgba(126, 214, 255, 0.8);
+  background: rgba(58, 174, 230, 0.82);
+  box-shadow:
+    0 0 18px rgba(90, 198, 255, 0.45),
+    0 0 32px rgba(90, 198, 255, 0.25);
+  cursor: pointer;
+  transition:
+    transform 0.25s ease,
+    background-color 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.network-marker::before,
+.network-marker::after {
+  content: "";
+  position: absolute;
+  inset: -8px;
+  border-radius: 50%;
+  pointer-events: none;
+  opacity: 0;
+}
+
+.network-marker::before {
+  border: 1px solid rgba(126, 214, 255, 0.4);
+  animation: networkPing 4.2s ease-out infinite;
+}
+
+.network-marker::after {
+  inset: -3px;
+  background: radial-gradient(circle, rgba(126, 214, 255, 0.3), rgba(126, 214, 255, 0));
+  transition: opacity 0.25s ease;
+}
+
+.network-marker:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 1px rgba(126, 214, 255, 0.8),
+    0 0 18px rgba(126, 214, 255, 0.55);
+}
+
+.network-marker.is-active {
+  background: var(--accent-red);
+  border-color: rgba(255, 138, 138, 0.85);
+  box-shadow:
+    0 0 20px rgba(255, 86, 86, 0.55),
+    0 0 40px rgba(255, 86, 86, 0.35);
+  transform: translate(-50%, -50%) scale(1.15);
+}
+
+.network-marker.is-active::before {
+  opacity: 1;
+  animation-duration: 2.6s;
+  border-color: rgba(255, 138, 138, 0.4);
+}
+
+.network-marker.is-active::after {
+  opacity: 1;
+  background: radial-gradient(circle, rgba(255, 138, 138, 0.32), rgba(255, 138, 138, 0));
+}
+
+.map-screen.is-targeting .map-overlay::after {
+  animation: labelGlitch 1.2s ease-out;
 }
 
 .map-coords {
@@ -2863,92 +2681,6 @@ body::after {
     line-height: 1.4;
     word-break: break-word;
   }
-}
-
-.network-pin {
-  position: relative;
-  width: 28px !important;
-  height: 28px !important;
-}
-
-.pin-tail {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: 2px;
-  height: 18px;
-  background: rgba(255, 255, 255, 0.4);
-}
-
-.pin-core {
-  position: absolute;
-  bottom: 14px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--accent-red);
-  box-shadow: 0 0 14px rgba(255, 59, 59, 0.6);
-}
-
-.pin-pulse {
-  position: absolute;
-  bottom: 14px;
-  left: 50%;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 59, 59, 0.6);
-  transform: translate(-50%, 50%);
-  animation: signalPulse 4.5s ease-out infinite;
-}
-
-.active-location-marker {
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  width: 44px;
-  height: 44px;
-  filter: drop-shadow(0 0 16px rgba(209, 162, 104, 0.55));
-}
-
-.active-location-marker .marker-star {
-  position: relative;
-  display: inline-block;
-  font-size: 1.9rem;
-  line-height: 1;
-  color: var(--amber);
-  text-shadow:
-    0 0 14px rgba(209, 162, 104, 0.7),
-    0 0 32px rgba(209, 162, 104, 0.45);
-  animation: focusMarkerPulse 2.8s ease-in-out infinite;
-}
-
-.active-location-marker .marker-star::after {
-  content: "";
-  position: absolute;
-  inset: -14px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle,
-    rgba(209, 162, 104, 0.32) 0%,
-    rgba(209, 162, 104, 0.12) 40%,
-    rgba(209, 162, 104, 0) 74%
-  );
-  opacity: 0.82;
-  animation: focusMarkerHalo 3.4s ease-in-out infinite;
-  pointer-events: none;
-  z-index: -1;
-}
-
-.network-tooltip {
-  background: rgba(15, 18, 20, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: var(--text-strong);
-  font-size: 0.62rem;
-  letter-spacing: 0.24em;
-  padding: 6px 8px;
 }
 
 .visually-hidden {
@@ -2990,31 +2722,6 @@ body::after {
   }
 }
 
-@keyframes directiveArrival {
-  0% {
-    opacity: 0;
-    transform: translateY(-8px);
-  }
-  32% {
-    opacity: 1;
-    transform: translateY(3px);
-  }
-  58% {
-    transform: translateX(-1px);
-  }
-  74% {
-    transform: translateX(1px);
-  }
-  100% {
-    transform: translateX(0);
-  }
-}
-
-@keyframes directiveDot {
-  0% {
-    opacity: 0;
-    transform: scale(0.4);
-  }
   50% {
     opacity: 1;
     transform: scale(1.05);
@@ -3025,33 +2732,37 @@ body::after {
   }
 }
 
-@keyframes priorityPulse {
+@keyframes networkPing {
   0% {
-    box-shadow: 0 0 4px currentColor;
-    opacity: 1;
+    transform: scale(0.4);
+    opacity: 0.5;
   }
   60% {
-    box-shadow: 0 0 12px currentColor;
-    opacity: 0.8;
+    transform: scale(1.2);
+    opacity: 0.85;
   }
   100% {
-    box-shadow: 0 0 6px transparent;
-    opacity: 0.6;
+    transform: scale(1.8);
+    opacity: 0;
   }
 }
 
-@keyframes inputFlash {
+@keyframes labelGlitch {
   0% {
-    box-shadow:
-      inset 0 0 0 1px rgba(255, 59, 59, 0.32),
-      inset 0 0 24px rgba(255, 59, 59, 0.28);
-    background-color: rgba(86, 0, 0, 0.3);
+    opacity: 1;
+    transform: translateX(0);
+  }
+  28% {
+    opacity: 0.5;
+    transform: translateX(1.5px);
+  }
+  58% {
+    opacity: 0.9;
+    transform: translateX(-1px);
   }
   100% {
-    box-shadow:
-      inset 0 0 0 1px rgba(255, 59, 59, 0.12),
-      inset 0 0 14px rgba(0, 0, 0, 0.45);
-    background-color: rgba(255, 255, 255, 0.04);
+    opacity: 1;
+    transform: translateX(0);
   }
 }
 

--- a/resources/views/portal/index.phtml
+++ b/resources/views/portal/index.phtml
@@ -3,13 +3,10 @@
  * @var array<int, array{id:int,title:string,done:bool,updated_at:int|null,updated_label:string,updated_iso:string,url:string}> $todoItems
  * @var array<int, array{id:int,title:string,status:string,status_label:string,summary:string,nodes:array<int,string>,node_count:int,updated_at:int|null,updated_label:string,updated_iso:string,url:string}> $mindmaps
  * @var array<int, array<string, mixed>> $recentFiles
- * @var array<int, array<string, mixed>> $directives
  * @var callable(string):string $asset
  * @var string $memoUrl
  * @var string $mindmapUrl
  * @var string $basePath
- * @var string $csrfToken
- * @var string $directivesPostUrl
  */
 ?>
 <!doctype html>
@@ -437,75 +434,6 @@
             <span class="encrypted-file__glare" aria-hidden="true"></span>
           </div>
         </section>
-        <section class="directive-block" aria-labelledby="directive-heading">
-          <header class="section-heading" id="directive-heading">
-            DIRECTIVES
-          </header>
-          <ul class="directive-log">
-            <?php if ($directives !== []): ?>
-              <?php foreach ($directives as $directive): ?>
-                <li class="directive-entry" data-priority="<?= view_escape((string)$directive['priority']); ?>">
-                  <span class="directive-content">
-                    <span class="directive-priority <?= view_escape((string)$directive['priority']); ?>" aria-hidden="true"></span>
-                    <span class="directive-text">
-                      <span class="directive-message"><?= view_escape((string)$directive['message']); ?></span>
-                      <span class="directive-meta">
-                        <span class="directive-author" aria-label="Author"><?= view_escape((string)$directive['nickname']); ?></span>
-                        <span class="directive-divider" aria-hidden="true">—</span>
-                        <time class="directive-time"<?php if (($directive['created_iso'] ?? '') !== ''): ?> datetime="<?= view_escape((string)$directive['created_iso']); ?>"<?php endif; ?>>
-                          <?= view_escape((string)$directive['created_label']); ?>
-                        </time>
-                      </span>
-                    </span>
-                    <span class="visually-hidden">Priority <?= view_escape(strtoupper((string)$directive['priority'])); ?></span>
-                  </span>
-                </li>
-              <?php endforeach; ?>
-            <?php else: ?>
-              <li class="directive-entry directive-entry--empty" data-priority="medium">
-                <span class="directive-content">
-                  <span class="directive-priority medium" aria-hidden="true"></span>
-                  <span class="directive-text">
-                    <span class="directive-message">暂无留言，成为第一位发言者。</span>
-                  </span>
-                </span>
-              </li>
-            <?php endif; ?>
-          </ul>
-          <form
-            class="note-form"
-            autocomplete="off"
-            method="post"
-            action="<?= view_escape($directivesPostUrl); ?>"
-            data-endpoint="<?= view_escape($directivesPostUrl); ?>"
-          >
-            <input type="hidden" name="_csrf" value="<?= view_escape($csrfToken); ?>" />
-            <div class="note-form-fields">
-              <label class="visually-hidden" for="note-nickname">留言昵称</label>
-              <input
-                id="note-nickname"
-                name="nickname"
-                type="text"
-                maxlength="40"
-                placeholder=">> 输入昵称"
-                aria-label="留言昵称"
-                required
-              />
-              <label class="visually-hidden" for="note-input">留言内容</label>
-              <input
-                id="note-input"
-                name="message"
-                type="text"
-                maxlength="240"
-                placeholder=">> 输入留言并按回车发送"
-                aria-label="输入新留言"
-                required
-              />
-            </div>
-            <p class="note-form-feedback" data-feedback role="status" aria-live="polite"></p>
-          </form>
-        </section>
-
         <section class="queue-card" aria-labelledby="queue-heading">
           <header class="section-heading" id="queue-heading">QUEUE</header>
           <ol class="queue-list">
@@ -672,13 +600,6 @@
         </section>
       </article>
     </section>
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"
-      integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-      defer
-    ></script>
     <script src="<?= view_escape($asset('script.js')); ?>" defer></script>
   </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,12 +9,11 @@ use Core\Router;
 $csrf = new CsrfMiddleware();
 $runner = new LegacyMemoRunner($config);
 $controller = new MemoController($runner, $csrf);
-$portal = new PortalController($csrf);
+$portal = new PortalController();
 
 /** @var Router $router */
 $router->get('/', [$portal, 'index']);
 $router->get('/index.php', [$portal, 'index']);
-$router->post('/directives', [$portal, 'storeDirective']);
 $router->get('/memo', [$controller, 'index']);
 $router->post('/memo', [$controller, 'store']);
 $router->get('/memo/index.php', [$controller, 'index']);


### PR DESCRIPTION
## Summary
- remove the directives guestbook from the portal controller, view, and routes while aligning dashboard widgets to show five records each
- drop the external Leaflet dependency and add a lightweight CSS/JS-driven network map implementation that avoids unsafe eval usage
- clean up portal styles and scripts to reflect the new static map layer and directive removal

## Testing
- php -l app/Controllers/PortalController.php
- php -l routes/web.php
- php tests/run.php


------
https://chatgpt.com/codex/tasks/task_e_68efea7d795c8328afcbb90a15d2ba29