### PR TITLE
调整平板区间布局与文件名截断逻辑

### DIFF
--- a/public/assets/portal/style.css
+++ b/public/assets/portal/style.css
@@ -1623,6 +1623,7 @@ body::after {
   letter-spacing: 0.22em;
   text-transform: uppercase;
   transition: color 0.2s ease, opacity 0.2s ease;
+  min-width: 0;
 }
 
 .file-entry-link:hover,
@@ -1635,11 +1636,17 @@ body::after {
   color: var(--text-muted);
   font-size: 0.68rem;
   min-width: 72px;
+  flex-shrink: 0;
 }
 
 .file-entry-name {
   color: var(--text-strong);
   font-size: 0.78rem;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .file-entry-meta {
@@ -3047,6 +3054,16 @@ body::after {
         28vw,
         250px
       );
+    gap: 28px;
+  }
+
+  .panel-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "signal"
+      "todo"
+      "files"
+      "board";
     gap: 28px;
   }
 }


### PR DESCRIPTION
## Summary
- 调整 1200px 以下的 panel-grid 为单列布局，让 1024-1200px 视口沿用平板排版以避免错位
- 为文件列表的长文件名补充弹性截断与编号宽度限制，防止超出容器

## Testing
- php tests/run.php
- npx stylelint public/assets/portal/style.css *(fails: No configuration provided)*

------
https://chatgpt.com/codex/tasks/task_e_68f08e390b6c832894c263e53ea16438